### PR TITLE
feat: implement on-chain event indexing service (#13)

### DIFF
--- a/bimex-indexer/.env.example
+++ b/bimex-indexer/.env.example
@@ -6,3 +6,5 @@ SUPABASE_KEY=<supabase_anon_key>
 START_LEDGER=0
 # Polling interval in milliseconds
 POLL_INTERVAL_MS=10000
+# Analytics API port
+API_PORT=3001

--- a/bimex-indexer/.env.example
+++ b/bimex-indexer/.env.example
@@ -1,0 +1,8 @@
+STELLAR_RPC_URL=https://mainnet.stellar.validationcloud.io/v1/<KEY>
+CONTRACT_ID=<MAINNET_CONTRACT_ID>
+SUPABASE_URL=<supabase_project_url>
+SUPABASE_KEY=<supabase_anon_key>
+# Ledger sequence to start indexing from (0 = latest)
+START_LEDGER=0
+# Polling interval in milliseconds
+POLL_INTERVAL_MS=10000

--- a/bimex-indexer/api.js
+++ b/bimex-indexer/api.js
@@ -1,0 +1,94 @@
+import 'dotenv/config';
+import http from 'node:http';
+import supabase from './database.js';
+
+const PORT = parseInt(process.env.API_PORT ?? '3001', 10);
+
+function json(res, status, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+  res.end(body);
+}
+
+async function route(req, res) {
+  const url = new URL(req.url, `http://localhost`);
+  const parts = url.pathname.replace(/^\//, '').split('/');
+
+  // GET /proyectos[?estado=X]
+  if (parts[0] === 'proyectos' && !parts[1]) {
+    let q = supabase.from('proyectos').select('*').order('id');
+    if (url.searchParams.has('estado')) q = q.eq('estado', url.searchParams.get('estado'));
+    const { data, error } = await q;
+    return error ? json(res, 500, { error: error.message }) : json(res, 200, data);
+  }
+
+  // GET /proyectos/:id
+  if (parts[0] === 'proyectos' && parts[1] && !parts[2]) {
+    const { data, error } = await supabase
+      .from('proyectos').select('*').eq('id', parts[1]).single();
+    if (error) return json(res, error.code === 'PGRST116' ? 404 : 500, { error: error.message });
+    return json(res, 200, data);
+  }
+
+  // GET /proyectos/:id/aportaciones
+  if (parts[0] === 'proyectos' && parts[1] && parts[2] === 'aportaciones') {
+    const { data, error } = await supabase
+      .from('aportaciones').select('*').eq('proyecto_id', parts[1]).order('timestamp');
+    return error ? json(res, 500, { error: error.message }) : json(res, 200, data);
+  }
+
+  // GET /backers/:address/aportaciones
+  if (parts[0] === 'backers' && parts[1] && parts[2] === 'aportaciones') {
+    const { data, error } = await supabase
+      .from('aportaciones').select('*, proyectos(nombre,estado)')
+      .eq('contribuidor', parts[1]).order('timestamp');
+    return error ? json(res, 500, { error: error.message }) : json(res, 200, data);
+  }
+
+  // GET /eventos[?tipo=X&limit=N]
+  if (parts[0] === 'eventos' && !parts[1]) {
+    const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '50', 10), 200);
+    let q = supabase.from('eventos').select('*').order('ledger', { ascending: false }).limit(limit);
+    if (url.searchParams.has('tipo')) q = q.eq('tipo', url.searchParams.get('tipo'));
+    const { data, error } = await q;
+    return error ? json(res, 500, { error: error.message }) : json(res, 200, data);
+  }
+
+  // GET /stats
+  if (parts[0] === 'stats' && !parts[1]) {
+    const [proyectos, aportaciones] = await Promise.all([
+      supabase.from('proyectos').select('estado,total_aportado,yield_entregado,meta'),
+      supabase.from('aportaciones').select('monto,retirado'),
+    ]);
+    if (proyectos.error) return json(res, 500, { error: proyectos.error.message });
+
+    const ps = proyectos.data;
+    const stats = {
+      total_proyectos:   ps.length,
+      activos:           ps.filter(p => ['EtapaInicial','EnProgreso','Liberado'].includes(p.estado)).length,
+      total_aportado:    ps.reduce((s, p) => s + Number(p.total_aportado ?? 0), 0),
+      total_yield:       ps.reduce((s, p) => s + Number(p.yield_entregado ?? 0), 0),
+      capital_activo:    (aportaciones.data ?? [])
+                           .filter(a => !a.retirado)
+                           .reduce((s, a) => s + Number(a.monto ?? 0), 0),
+    };
+    return json(res, 200, stats);
+  }
+
+  json(res, 404, { error: 'Not found' });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET' });
+    return res.end();
+  }
+  if (req.method !== 'GET') return json(res, 405, { error: 'Method not allowed' });
+  try {
+    await route(req, res);
+  } catch (err) {
+    json(res, 500, { error: err.message });
+  }
+});
+
+server.listen(PORT, () => console.log(`Bimex API listening on port ${PORT}`));

--- a/bimex-indexer/database.js
+++ b/bimex-indexer/database.js
@@ -1,0 +1,40 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_KEY
+);
+
+export async function upsertProyecto(proyecto) {
+  const { error } = await supabase
+    .from('proyectos')
+    .upsert(proyecto, { onConflict: 'id' });
+  if (error) throw error;
+}
+
+export async function upsertAportacion(aportacion) {
+  const { error } = await supabase
+    .from('aportaciones')
+    .upsert(aportacion, { onConflict: 'proyecto_id,contribuidor' });
+  if (error) throw error;
+}
+
+export async function insertEvento(evento) {
+  // Ignore duplicate tx_hash (idempotent re-indexing)
+  const { error } = await supabase
+    .from('eventos')
+    .upsert(evento, { onConflict: 'tx_hash', ignoreDuplicates: true });
+  if (error) throw error;
+}
+
+export async function getLastIndexedLedger() {
+  const { data, error } = await supabase
+    .from('eventos')
+    .select('ledger')
+    .order('ledger', { ascending: false })
+    .limit(1);
+  if (error || !data?.length) return null;
+  return data[0].ledger;
+}
+
+export default supabase;

--- a/bimex-indexer/database.js
+++ b/bimex-indexer/database.js
@@ -6,6 +6,16 @@ const supabase = createClient(
 );
 
 export async function upsertProyecto(proyecto) {
+  // reclamar_yield sends a delta, not an absolute value — increment in DB
+  if (proyecto.yield_entregado_delta != null) {
+    const { id, yield_entregado_delta } = proyecto;
+    const { error } = await supabase.rpc('incrementar_yield_entregado', {
+      p_id: id,
+      p_delta: yield_entregado_delta,
+    });
+    if (error) throw error;
+    return;
+  }
   const { error } = await supabase
     .from('proyectos')
     .upsert(proyecto, { onConflict: 'id' });

--- a/bimex-indexer/eventParser.js
+++ b/bimex-indexer/eventParser.js
@@ -2,7 +2,7 @@ import { xdr, scValToNative, Address } from '@stellar/stellar-sdk';
 
 const CONTRACT_FUNCTIONS = new Set([
   'crear_proyecto', 'contribuir', 'reclamar_yield',
-  'retirar_principal', 'abandonar_proyecto',
+  'retirar_principal', 'abandonar_proyecto', 'solicitar_continuar',
   'admin_aprobar', 'admin_rechazar',
 ]);
 
@@ -12,6 +12,7 @@ const FN_TO_EVENT = {
   reclamar_yield:     'yield_reclamado',
   retirar_principal:  'retiro_principal',
   abandonar_proyecto: 'cambio_estado',
+  solicitar_continuar:'cambio_estado',
   admin_aprobar:      'cambio_estado',
   admin_rechazar:     'cambio_estado',
 };
@@ -88,6 +89,22 @@ export function parseTx(tx, contractId) {
         proyecto = { id: Number(args[0]), estado: 'Rechazado', motivo_rechazo: String(args[1]) };
       } else if (fnName === 'abandonar_proyecto') {
         proyecto = { id: Number(args[0]), estado: 'Abandonado' };
+      } else if (fnName === 'solicitar_continuar') {
+        // args: [nuevo_dueno, id_proyecto]
+        proyecto = { id: Number(args[1]), dueno: String(args[0]), estado: 'EnProgreso' };
+      } else if (fnName === 'reclamar_yield') {
+        // args: [id_proyecto]; returnValue is the yield amount claimed
+        const monto = tx.returnValue ? scValToNative(tx.returnValue) : null;
+        proyecto = { id: Number(args[0]), yield_entregado_delta: monto !== null ? String(monto) : null };
+      } else if (fnName === 'retirar_principal') {
+        // args: [backer, id_proyecto]
+        aportacion = {
+          proyecto_id:  Number(args[1]),
+          contribuidor: String(args[0]),
+          monto:        '0',
+          retirado:     true,
+          timestamp,
+        };
       }
 
       return { evento, proyecto, aportacion };

--- a/bimex-indexer/eventParser.js
+++ b/bimex-indexer/eventParser.js
@@ -1,0 +1,99 @@
+import { xdr, scValToNative, Address } from '@stellar/stellar-sdk';
+
+const CONTRACT_FUNCTIONS = new Set([
+  'crear_proyecto', 'contribuir', 'reclamar_yield',
+  'retirar_principal', 'abandonar_proyecto',
+  'admin_aprobar', 'admin_rechazar',
+]);
+
+const FN_TO_EVENT = {
+  crear_proyecto:     'nuevo_proyecto',
+  contribuir:         'nueva_aportacion',
+  reclamar_yield:     'yield_reclamado',
+  retirar_principal:  'retiro_principal',
+  abandonar_proyecto: 'cambio_estado',
+  admin_aprobar:      'cambio_estado',
+  admin_rechazar:     'cambio_estado',
+};
+
+/**
+ * Parse a TransactionInfo object from SorobanRpc.getTransactions().
+ * The SDK already decodes XDR fields into xdr.* objects.
+ * Returns { evento, proyecto, aportacion } or null if not a Bimex tx.
+ */
+export function parseTx(tx, contractId) {
+  try {
+    // envelopeXdr is already an xdr.TransactionEnvelope (SDK-parsed)
+    const envelope = tx.envelopeXdr;
+    const ops = envelope.v1?.tx?.operations() ?? envelope.tx?.operations() ?? [];
+
+    for (const op of ops) {
+      const body = op.body();
+      if (body.switch().name !== 'invokeHostFunction') continue;
+
+      const hostFn = body.invokeHostFunction().hostFunction();
+      if (hostFn.switch().name !== 'hostFunctionTypeInvokeContract') continue;
+
+      const invokeArgs = hostFn.invokeContract();
+
+      // Convert xdr.ScAddress → Strkey string (C...) for comparison
+      const contractStrkey = Address.fromScAddress(
+        invokeArgs.contractAddress()
+      ).toString();
+
+      if (contractStrkey !== contractId) continue;
+
+      const fnName = invokeArgs.functionName().toString();
+      if (!CONTRACT_FUNCTIONS.has(fnName)) continue;
+
+      const args = invokeArgs.args().map(scValToNative);
+      const timestamp = new Date(tx.createdAt * 1000).toISOString();
+
+      const evento = {
+        tipo:        FN_TO_EVENT[fnName],
+        contract_id: contractId,
+        fn_name:     fnName,
+        data:        args,
+        ledger:      tx.ledger,
+        timestamp,
+        tx_hash:     tx.txHash,
+      };
+
+      let proyecto = null;
+      let aportacion = null;
+
+      if (fnName === 'crear_proyecto') {
+        // args: [dueno, nombre, meta, doc_hash]
+        // returnValue is xdr.ScVal (u32 project id), present on SUCCESS
+        const id = tx.returnValue ? scValToNative(tx.returnValue) : null;
+        proyecto = {
+          id,
+          dueno:      String(args[0]),
+          nombre:     String(args[1]),
+          meta:       String(args[2]),
+          estado:     'EnRevision',
+          created_at: timestamp,
+        };
+      } else if (fnName === 'contribuir') {
+        // args: [backer, id_proyecto, cantidad]
+        aportacion = {
+          proyecto_id:  Number(args[1]),
+          contribuidor: String(args[0]),
+          monto:        String(args[2]),
+          timestamp,
+        };
+      } else if (fnName === 'admin_aprobar') {
+        proyecto = { id: Number(args[0]), estado: 'EtapaInicial' };
+      } else if (fnName === 'admin_rechazar') {
+        proyecto = { id: Number(args[0]), estado: 'Rechazado', motivo_rechazo: String(args[1]) };
+      } else if (fnName === 'abandonar_proyecto') {
+        proyecto = { id: Number(args[0]), estado: 'Abandonado' };
+      }
+
+      return { evento, proyecto, aportacion };
+    }
+  } catch {
+    // Malformed or irrelevant tx — skip
+  }
+  return null;
+}

--- a/bimex-indexer/index.js
+++ b/bimex-indexer/index.js
@@ -19,7 +19,6 @@ async function getStartLedger() {
 }
 
 async function processBatch(startLedger) {
-  // limit goes inside pagination per the SDK's GetTransactionsRequest type
   const resp = await rpc.getTransactions({
     startLedger,
     pagination: { limit: 200 },
@@ -38,10 +37,9 @@ async function processBatch(startLedger) {
     console.log(`[${new Date().toISOString()}] ${evento.tipo} ledger=${evento.ledger} tx=${evento.tx_hash}`);
   }
 
-  // Advance to the ledger after the last one we just processed.
-  // latestLedger is the chain tip; we use it as the next poll start
-  // only if we've caught up (no more pages). Otherwise use cursor.
-  return resp.latestLedger;
+  // cursor is the ledger sequence to use as startLedger on the next call.
+  // When we've caught up to the tip, cursor equals latestLedger + 1.
+  return resp.cursor ?? resp.latestLedger + 1;
 }
 
 async function run() {

--- a/bimex-indexer/index.js
+++ b/bimex-indexer/index.js
@@ -1,0 +1,61 @@
+import 'dotenv/config';
+import { SorobanRpc } from '@stellar/stellar-sdk';
+import { parseTx } from './eventParser.js';
+import { upsertProyecto, upsertAportacion, insertEvento, getLastIndexedLedger } from './database.js';
+
+const RPC_URL         = process.env.STELLAR_RPC_URL;
+const CONTRACT_ID     = process.env.CONTRACT_ID;
+const START_LEDGER    = parseInt(process.env.START_LEDGER ?? '0', 10);
+const POLL_INTERVAL   = parseInt(process.env.POLL_INTERVAL_MS ?? '10000', 10);
+
+const rpc = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
+
+async function getStartLedger() {
+  if (START_LEDGER > 0) return START_LEDGER;
+  const last = await getLastIndexedLedger();
+  if (last) return last + 1;
+  const latest = await rpc.getLatestLedger();
+  return latest.sequence;
+}
+
+async function processBatch(startLedger) {
+  // limit goes inside pagination per the SDK's GetTransactionsRequest type
+  const resp = await rpc.getTransactions({
+    startLedger,
+    pagination: { limit: 200 },
+  });
+
+  for (const tx of resp.transactions ?? []) {
+    if (tx.status !== 'SUCCESS') continue;
+    const parsed = parseTx(tx, CONTRACT_ID);
+    if (!parsed) continue;
+
+    const { evento, proyecto, aportacion } = parsed;
+    await insertEvento(evento).catch(console.error);
+    if (proyecto)   await upsertProyecto(proyecto).catch(console.error);
+    if (aportacion) await upsertAportacion(aportacion).catch(console.error);
+
+    console.log(`[${new Date().toISOString()}] ${evento.tipo} ledger=${evento.ledger} tx=${evento.tx_hash}`);
+  }
+
+  // Advance to the ledger after the last one we just processed.
+  // latestLedger is the chain tip; we use it as the next poll start
+  // only if we've caught up (no more pages). Otherwise use cursor.
+  return resp.latestLedger;
+}
+
+async function run() {
+  let cursor = await getStartLedger();
+  console.log(`Bimex indexer starting at ledger ${cursor}`);
+
+  while (true) {
+    try {
+      cursor = await processBatch(cursor);
+    } catch (err) {
+      console.error('Poll error:', err.message);
+    }
+    await new Promise(r => setTimeout(r, POLL_INTERVAL));
+  }
+}
+
+run();

--- a/bimex-indexer/package.json
+++ b/bimex-indexer/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "api": "node api.js"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.3.0",

--- a/bimex-indexer/package.json
+++ b/bimex-indexer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bimex-indexer",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^12.3.0",
+    "@supabase/supabase-js": "^2.43.0",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/bimex-indexer/schema.sql
+++ b/bimex-indexer/schema.sql
@@ -1,0 +1,42 @@
+-- Bimex Indexer Schema
+-- Run in Supabase SQL editor or as a migration
+
+create table if not exists proyectos (
+  id              integer primary key,
+  dueno           text,
+  nombre          text,
+  meta            numeric,
+  total_aportado  numeric default 0,
+  yield_entregado numeric default 0,
+  estado          text,
+  motivo_rechazo  text,
+  created_at      timestamptz
+);
+
+create table if not exists aportaciones (
+  proyecto_id  integer references proyectos(id),
+  contribuidor text,
+  monto        numeric,
+  timestamp    timestamptz,
+  primary key (proyecto_id, contribuidor)
+);
+
+create table if not exists eventos (
+  id          bigserial primary key,
+  tipo        text not null,
+  contract_id text not null,
+  fn_name     text,
+  data        jsonb,
+  ledger      bigint,
+  tx_hash     text unique,
+  timestamp   timestamptz
+);
+
+-- Index for fast lookups
+create index if not exists eventos_tipo_idx      on eventos(tipo);
+create index if not exists eventos_ledger_idx    on eventos(ledger desc);
+create index if not exists aportaciones_proj_idx on aportaciones(proyecto_id);
+
+-- Enable Supabase realtime for live frontend updates
+alter publication supabase_realtime add table eventos;
+alter publication supabase_realtime add table proyectos;

--- a/bimex-indexer/schema.sql
+++ b/bimex-indexer/schema.sql
@@ -17,6 +17,7 @@ create table if not exists aportaciones (
   proyecto_id  integer references proyectos(id),
   contribuidor text,
   monto        numeric,
+  retirado     boolean default false,
   timestamp    timestamptz,
   primary key (proyecto_id, contribuidor)
 );
@@ -33,9 +34,18 @@ create table if not exists eventos (
 );
 
 -- Index for fast lookups
-create index if not exists eventos_tipo_idx      on eventos(tipo);
-create index if not exists eventos_ledger_idx    on eventos(ledger desc);
-create index if not exists aportaciones_proj_idx on aportaciones(proyecto_id);
+create index if not exists eventos_tipo_idx         on eventos(tipo);
+create index if not exists eventos_ledger_idx       on eventos(ledger desc);
+create index if not exists aportaciones_proj_idx    on aportaciones(proyecto_id);
+create index if not exists aportaciones_backer_idx  on aportaciones(contribuidor);
+
+-- Atomic yield increment (avoids read-modify-write race)
+create or replace function incrementar_yield_entregado(p_id integer, p_delta numeric)
+returns void language sql as $$
+  update proyectos
+  set yield_entregado = yield_entregado + p_delta
+  where id = p_id;
+$$;
 
 -- Enable Supabase realtime for live frontend updates
 alter publication supabase_realtime add table eventos;


### PR DESCRIPTION
- Add bimex-indexer service with polling loop via SorobanRpc.getTransactions
- Parse contract invocations (crear_proyecto, contribuir, reclamar_yield, retirar_principal, abandonar_proyecto, admin_aprobar, admin_rechazar)
- Store events, projects and contributions in Supabase
- Idempotent re-indexing via upsert on tx_hash conflict
- Add schema.sql migration with realtime enabled for frontend subscriptions

 What this does                                                                                                                                          
                                                                                                                                                          
  Completes the bimex-indexer service so it correctly tracks all contract activity and exposes it via a queryable API for the frontend.                   
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  Bug fixes                                                                                                                                               
                                                                                                                                                          
  - index.js: processBatch was returning resp.latestLedger (the chain tip) as the next cursor, causing the indexer to skip ledgers whenever it was behind.
  Fixed to use resp.cursor ?? resp.latestLedger + 1.                                                                                                      
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  Event coverage                                                                                                                                          
                                                                                                                                                          
  Three contract functions were silently ignored by the parser:                                                                                           
                                                                                                                                                          
  ┌───────────────────────┬──────────────────────────────────────────────────────┐                                                                        
  │ Function              │ Now produces                                         │                                                                        
  ├───────────────────────┼──────────────────────────────────────────────────────┤                                                                        
  │ `solicitar_continuar` │ updates `proyecto.dueno` + `estado`                  │                                                                        
  │ `reclamar_yield`      │ increments `yield_entregado` from `tx.returnValue`   │                                                                        
  │ `retirar_principal`   │ zeros out `aportacion.monto`, sets `retirado = true` │                                                                        
  └───────────────────────┴──────────────────────────────────────────────────────┘                                                                        
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  Schema changes (schema.sql)                                                                                                                             
                                                                                                                                                          
  - aportaciones.retirado boolean default false — tracks whether a backer has recovered their principal                                                   
  - aportaciones_backer_idx — index on contribuidor for backer-centric queries                                                                            
  - incrementar_yield_entregado(p_id, p_delta) — Postgres function for atomic yield accumulation (avoids read-modify-write race on reclamar_yield)        
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  Analytics API (api.js — new file)                                                                                                                       
                                                                                                                                                          
  Minimal node:http server, no new dependencies. Start with npm run api.                                                                                  
                                                                                                                                                          
  GET /proyectos[?estado=X]                                                                                                                               
  GET /proyectos/:id                                                                                                                                      
  GET /proyectos/:id/aportaciones                                                                                                                         
  GET /backers/:address/aportaciones                                                                                                                      
  GET /eventos[?tipo=X&limit=N]                                                                                                                           
  GET /stats                                                                                                                                              
                                                                                                                                                          
  /stats returns aggregate totals: active capital, total yield delivered, project counts by state.                                                        
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  Files changed                                                                                                                                           
                                                                                                                                                          
  - bimex-indexer/index.js — cursor fix                                                                                                                   
  - bimex-indexer/eventParser.js — 3 missing functions + solicitar_continuar in event map                                                                 
  - bimex-indexer/database.js — yield delta via RPC, retirado flag on upsert                                                                              
  - bimex-indexer/schema.sql — new column, index, SQL function                                                                                            
  - bimex-indexer/api.js — new analytics REST server                                                                                                      
  - bimex-indexer/package.json — npm run api script                                                                                                       
  - bimex-indexer/.env.example — API_PORT variable                                                                                                        
                                                                    



closes #13