### PR TITLE
feat: connect Recompensas to real contract data with correct tier thr…

### DIFF
--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -127,6 +127,7 @@ export default function App() {
   const [adminPanel,     setAdminPanel]     = useState(false);
   const [autoConectar,   setAutoConectar]   = useState(leerAutoConectarInicial);
   const [cerrandoSesion, setCerrandoSesion] = useState(false);
+  const [totalInvertido, setTotalInvertido] = useState(null);
 
   const esAdmin = direccion === ADMIN_ADDRESS;
 
@@ -208,7 +209,7 @@ export default function App() {
             </button>
           )}
 
-          <Recompensas direccion={direccion} refrescar={refrescar} />
+          <Recompensas direccion={direccion} refrescar={refrescar} totalInvertido={totalInvertido} />
 
           <div className="wallet-chip">
             <span className="wallet-dot" aria-hidden="true" />
@@ -237,6 +238,7 @@ export default function App() {
           <MiCuenta
             direccion={direccion}
             onVerProyecto={p => { setProyectoActivo(p); setVistaActual("proyectos"); }}
+            onTotalInvertido={setTotalInvertido}
           />
         )}
 

--- a/bimex-frontend/src/components/MiCuenta.jsx
+++ b/bimex-frontend/src/components/MiCuenta.jsx
@@ -319,7 +319,7 @@ function TabMisContribuciones({ proyectos, direccion, onVerProyecto }) {
 
 // ─── Componente principal ─────────────────────────────────────────────────────
 
-export default function MiCuenta({ direccion, onVerProyecto }) {
+export default function MiCuenta({ direccion, onVerProyecto, onTotalInvertido }) {
   const [tab, setTab] = useState("proyectos");
   const [proyectos, setProyectos] = useState([]);
   const [cargando, setCargando] = useState(true);
@@ -364,8 +364,10 @@ export default function MiCuenta({ direccion, onVerProyecto }) {
         );
         if (cancelado) return;
         const positivos = resultados.filter((a) => a > BigInt(0));
+        const total = positivos.reduce((acc, a) => acc + a, BigInt(0));
         setNumApoyados(positivos.length);
-        setTotalInvertido(positivos.reduce((acc, a) => acc + a, BigInt(0)));
+        setTotalInvertido(total);
+        onTotalInvertido?.(total);
       } catch (e) {
         console.error("Error calculando resumen:", e);
         if (!cancelado) {

--- a/bimex-frontend/src/components/Recompensas.jsx
+++ b/bimex-frontend/src/components/Recompensas.jsx
@@ -2,61 +2,62 @@ import { useState, useEffect, useRef } from "react";
 import { obtenerTodosLosProyectos, obtenerAportacion, stroopsAMXNe } from "../stellar/contrato";
 
 // ── Niveles de confianza ──────────────────────────────────────────────────────
+// Thresholds in MXNe (1 MXNe = 10_000_000 stroops)
 const NIVELES = [
   {
     id: "semilla",
     nombre: "Semilla",
     icono: "🌱",
     min: 0,
-    max: 499,
+    max: 999,
     color: "#7C3AED",
     bg: "rgba(124,58,237,0.07)",
     border: "rgba(124,58,237,0.18)",
     recompensas: [
-      { id: "r1", nombre: "Badge Semilla", desc: "Tu primer paso en Bimex", icono: "🏅", umbral: 0,    desbloqueado: true  },
-      { id: "r2", nombre: "Primer aporte", desc: "Contribuiste tu primer MXNe", icono: "💚", umbral: 1,    desbloqueado: false },
+      { id: "r1", nombre: "Badge Semilla", desc: "Tu primer paso en Bimex",        icono: "🏅", umbral: 0,   desbloqueado: true  },
+      { id: "r2", nombre: "Primer aporte", desc: "Contribuiste tu primer MXNe",    icono: "💚", umbral: 1,   desbloqueado: false },
     ],
   },
   {
     id: "brote",
     nombre: "Brote",
     icono: "🌿",
-    min: 500,
-    max: 1999,
+    min: 1_000,
+    max: 9_999,
     color: "#059669",
     bg: "rgba(5,150,105,0.07)",
     border: "rgba(5,150,105,0.18)",
     recompensas: [
-      { id: "r3", nombre: "Inversor Brote",    desc: "Invertiste 500+ MXNe en total",     icono: "🌿", umbral: 500,   desbloqueado: false },
-      { id: "r4", nombre: "🎁 Regalo sorpresa", desc: "Desbloquea al llegar a 1,000 MXNe", icono: "🎁", umbral: 1000,  desbloqueado: false },
+      { id: "r3", nombre: "Inversor Brote",    desc: "Invertiste 1,000+ MXNe en total",    icono: "🌿", umbral: 1_000,  desbloqueado: false },
+      { id: "r4", nombre: "🎁 Regalo sorpresa", desc: "Desbloquea al llegar a 5,000 MXNe", icono: "🎁", umbral: 5_000,  desbloqueado: false },
     ],
   },
   {
     id: "arbol",
     nombre: "Árbol",
     icono: "🌳",
-    min: 2000,
-    max: 9999,
+    min: 10_000,
+    max: 99_999,
     color: "#D97706",
     bg: "rgba(217,119,6,0.07)",
     border: "rgba(217,119,6,0.18)",
     recompensas: [
-      { id: "r5", nombre: "Árbol de impacto", desc: "Invertiste 2,000+ MXNe",              icono: "🌳", umbral: 2000,  desbloqueado: false },
-      { id: "r6", nombre: "🎁 Caja misteriosa", desc: "Acceso exclusivo a proyectos VIP",  icono: "📦", umbral: 5000,  desbloqueado: false },
+      { id: "r5", nombre: "Árbol de impacto",  desc: "Invertiste 10,000+ MXNe",             icono: "🌳", umbral: 10_000, desbloqueado: false },
+      { id: "r6", nombre: "🎁 Caja misteriosa", desc: "Acceso exclusivo a proyectos VIP",   icono: "📦", umbral: 50_000, desbloqueado: false },
     ],
   },
   {
     id: "selva",
     nombre: "Selva",
-    icono: "🏔️",
-    min: 10000,
+    icono: "🌲",
+    min: 100_000,
     max: Infinity,
-    color: "#4F46E5",
-    bg: "rgba(79,70,229,0.07)",
-    border: "rgba(79,70,229,0.18)",
+    color: "#065F46",
+    bg: "rgba(6,95,70,0.07)",
+    border: "rgba(6,95,70,0.18)",
     recompensas: [
-      { id: "r7", nombre: "Guardián Selva",    desc: "Invertiste 10,000+ MXNe",             icono: "🏔️", umbral: 10000, desbloqueado: false },
-      { id: "r8", nombre: "🎁 NFT exclusivo",  desc: "NFT de colección arte mexicano",       icono: "🎨", umbral: 20000, desbloqueado: false },
+      { id: "r7", nombre: "Guardián Selva",   desc: "Invertiste 100,000+ MXNe",       icono: "🌲", umbral: 100_000, desbloqueado: false },
+      { id: "r8", nombre: "🎁 NFT exclusivo", desc: "NFT de colección arte mexicano",  icono: "🎨", umbral: 200_000, desbloqueado: false },
     ],
   },
 ];
@@ -76,16 +77,23 @@ function calcularRecompensas(totalMXNe) {
 }
 
 // ── Componente principal ──────────────────────────────────────────────────────
-export default function Recompensas({ direccion, refrescar }) {
+// totalInvertido: BigInt en stroops (opcional). Si se pasa, se omite el fetch propio.
+export default function Recompensas({ direccion, refrescar, totalInvertido: totalInvertidoProp }) {
   const [abierto,    setAbierto]    = useState(false);
   const [totalMXNe,  setTotalMXNe]  = useState(0);
-  const [cargando,   setCargando]   = useState(true);
+  const [cargando,   setCargando]   = useState(!totalInvertidoProp);
   const [sorpresa,   setSorpresa]   = useState(null);
   const panelRef = useRef(null);
   const botonRef = useRef(null);
 
-  // Carga el total invertido sumando todas las aportaciones del usuario
+  // Si el padre ya calculó totalInvertido, úsalo directamente (no double-fetch)
   useEffect(() => {
+    if (totalInvertidoProp != null) {
+      setTotalMXNe(Number(BigInt(totalInvertidoProp)) / 10_000_000);
+      setCargando(false);
+      return;
+    }
+    // Fallback: fetch propio cuando no se pasa el prop
     if (!direccion) return;
     (async () => {
       setCargando(true);
@@ -102,7 +110,7 @@ export default function Recompensas({ direccion, refrescar }) {
         setCargando(false);
       }
     })();
-  }, [direccion, refrescar]);
+  }, [direccion, refrescar, totalInvertidoProp]);
 
   // Cierra con Escape o clic fuera
   useEffect(() => {


### PR DESCRIPTION

closes #17 

Title:                                                                                                                                                  
                                                                                                                                                          
  feat: connect Recompensas to real contract data with correct tier thresholds (Issue #17)                                                                
                                                                                                                                                          
  Description:                                                                                                                                            
                                                                                                                                                          
  ## Summary                                                                                                                                              
  Connects the Recompensas component to real on-chain investment data and fixes tier thresholds to match the spec.                                        
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  ### Recompensas.jsx                                                                                                                                     
  - Fixed tier thresholds to match spec:                                                                                                                  
    | Tier | Name | Range |                                                                                                                               
    |---|---|---|                                                                                                                                         
    | 1 | Semilla 🌱 | 0 – 999 MXNe |                                                                                                                     
    | 2 | Brote 🌿 | 1,000 – 9,999 MXNe |                                                                                                                 
    | 3 | Árbol 🌳 | 10,000 – 99,999 MXNe |                                                                                                               
    | 4 | Selva 🌲 | 100,000+ MXNe |                                                                                                                      
  - Selva color updated to forest green (`#065F46`), icon changed from 🏔️ to 🌲                                                                           
  - Accepts `totalInvertido` prop (BigInt in stroops) — when provided, skips its own RPC fetch entirely                                                   
  - Falls back to its own fetch when prop is not provided (backward compatible)                                                                           
                                                                                                                                                          
  ### MiCuenta.jsx                                                                                                                                        
  - Added `onTotalInvertido` callback prop                                                                                                                
  - Calls `onTotalInvertido(total)` when the investment total is calculated — reuses the existing fetch, no extra RPC calls                               
                                                                                                                                                          
  ### App.jsx                                                                                                                                             
  - Added `totalInvertido` state                                                                                                                          
  - Passes `onTotalInvertido={setTotalInvertido}` to `MiCuenta`                                                                                           
  - Passes `totalInvertido={totalInvertido}` to `Recompensas`                                                                                             
                                                                                                                                                          
  ## Data Flow                                                                                                                                            
                                                                                                                                                          
  MiCuenta (calculates total) → onTotalInvertido() → App state → Recompensas prop                                                                         
                                                                                                                                                          
  Single RPC fetch, shared across both components. Tier in navbar always matches total shown in Mi Cuenta.                                                
                                                                                                                                                          
  ## Stroops conversion                                                                                                                                   
  `1 MXNe = 10,000,000 stroops` — conversion handled in `Recompensas` as `Number(BigInt(prop)) / 10_000_000`                                              
                                                                                                                                                          
                                                                                                                                                                            
- Fix tier thresholds to match spec: Semilla 0-999, Brote 1k-9.9k, Árbol 10k-99.9k, Selva 100k+ MXNe
- Selva color updated to forest green (#065F46), icon changed to 🌲
- Recompensas accepts totalInvertido prop (BigInt stroops) to skip double-fetch
- MiCuenta calls onTotalInvertido() callback when total is calculated
- App.jsx stores totalInvertido in state and passes it to Recompensas
- Recompensas falls back to its own fetch when prop is not provided
