### PR TITLE
fix: ajustar tasas reales — CETES 945 bps (9.45%), AMM 400 bps (4%) (#3)

### DIFF
--- a/bimex/contracts/bimex/src/lib.rs
+++ b/bimex/contracts/bimex/src/lib.rs
@@ -77,6 +77,15 @@ pub enum Clave {
 }
 
 // ============================================================
+//  CONSTANTES DE TASAS
+// ============================================================
+
+// Tasas reales de producción en puntos base (bps).
+// 10 000 bps = 100 % anual. Fórmula: capital × bps × minutos / 10_000 / 525_600
+const DEFAULT_CETES_BPS: u32 = 945;  // 9.45 % anual (CETES referencia)
+const DEFAULT_AMM_BPS:   u32 = 400;  // 4.00 % anual (liquidez AMM)
+
+// ============================================================
 //  HELPERS
 // ============================================================
 
@@ -211,8 +220,8 @@ impl BimexContrato {
             .storage().persistent().get(&Clave::Aportacion(id_proyecto, backer))
             .expect("Este backer no tiene aportacion en este proyecto");
 
-        let cetes_bps = env.storage().instance().get::<_, u32>(&Clave::YieldCetesBps).unwrap_or(25000) as i128;
-        let amm_bps   = env.storage().instance().get::<_, u32>(&Clave::YieldAmmBps).unwrap_or(10000) as i128;
+        let cetes_bps = env.storage().instance().get::<_, u32>(&Clave::YieldCetesBps).unwrap_or(DEFAULT_CETES_BPS) as i128;
+        let amm_bps   = env.storage().instance().get::<_, u32>(&Clave::YieldAmmBps).unwrap_or(DEFAULT_AMM_BPS) as i128;
 
         let segundos = env.ledger().timestamp().saturating_sub(aportacion.timestamp);
         let minutos  = (segundos / 60) as i128;
@@ -229,8 +238,8 @@ impl BimexContrato {
             .storage().persistent().get(&Clave::Proyecto(id_proyecto))
             .expect("Proyecto no existe");
 
-        let cetes_bps = env.storage().instance().get::<_, u32>(&Clave::YieldCetesBps).unwrap_or(25000) as i128;
-        let amm_bps   = env.storage().instance().get::<_, u32>(&Clave::YieldAmmBps).unwrap_or(10000) as i128;
+        let cetes_bps = env.storage().instance().get::<_, u32>(&Clave::YieldCetesBps).unwrap_or(DEFAULT_CETES_BPS) as i128;
+        let amm_bps   = env.storage().instance().get::<_, u32>(&Clave::YieldAmmBps).unwrap_or(DEFAULT_AMM_BPS) as i128;
 
         let segundos = env.ledger().timestamp().saturating_sub(proyecto.timestamp_inicio);
         let minutos  = (segundos / 60) as i128;
@@ -269,8 +278,8 @@ impl BimexContrato {
         );
         assert!(proyecto.total_aportado > 0, "No hay fondos en el proyecto");
 
-        let cetes_bps = env.storage().instance().get::<_, u32>(&Clave::YieldCetesBps).unwrap_or(25000) as i128;
-        let amm_bps   = env.storage().instance().get::<_, u32>(&Clave::YieldAmmBps).unwrap_or(10000) as i128;
+        let cetes_bps = env.storage().instance().get::<_, u32>(&Clave::YieldCetesBps).unwrap_or(DEFAULT_CETES_BPS) as i128;
+        let amm_bps   = env.storage().instance().get::<_, u32>(&Clave::YieldAmmBps).unwrap_or(DEFAULT_AMM_BPS) as i128;
 
         let ahora    = env.ledger().timestamp();
         let segundos = ahora.saturating_sub(proyecto.timestamp_inicio);

--- a/bimex/contracts/bimex/src/test.rs
+++ b/bimex/contracts/bimex/src/test.rs
@@ -29,7 +29,7 @@ fn setup() -> (Env, BimexContratoClient<'static>, Address, Address, Address) {
     let cliente     = BimexContratoClient::new(&env, &contrato_id);
     asset.mint(&contrato_id, &100_000_000_000i128);
 
-    cliente.inicializar(&admin, &token_mxne, &5_000_000u32, &2_000_000u32);
+    cliente.inicializar(&admin, &token_mxne, &945u32, &400u32);
     (env, cliente, admin, dueno, backer)
 }
 
@@ -58,7 +58,7 @@ fn test_flujo_completo() {
     let cliente     = BimexContratoClient::new(&env, &contrato_id);
     asset.mint(&contrato_id, &100_000_000_000i128);
 
-    cliente.inicializar(&admin, &token_mxne, &5_000_000u32, &2_000_000u32);
+    cliente.inicializar(&admin, &token_mxne, &945u32, &400u32);
 
     let id = cliente.crear_proyecto(
         &dueno,
@@ -337,4 +337,81 @@ fn test_vul09_no_retirar_en_progreso() {
     assert_eq!(cliente.obtener_proyecto(&id).estado, EstadoProyecto::EnProgreso);
     // Must not allow withdrawal while project is still in progress
     cliente.retirar_principal(&backer, &id);
+}
+
+// ============================================================
+//  TASAS REALES DE PRODUCCIÓN
+// ============================================================
+
+/// Verifica que las tasas de producción (CETES 945 bps, AMM 400 bps) producen
+/// el yield correcto a un año.  Con un proyecto de 1 000 MXNe (capital dividido
+/// 50 / 50 entre CETES y AMM):
+///   - 500 MXNe × 9.45 % ≈ 47.25 MXNe en CETES
+///   - 500 MXNe × 4.00 % ≈ 20.00 MXNe en AMM
+/// Se tolera un margen de ±2 MXNe por truncamiento en aritmética entera.
+#[test]
+fn test_yield_tasas_reales_produccion() {
+    let (env, cliente, _admin, dueno, backer) = setup();
+
+    // 1 000 MXNe meta (1 000 000 000 stroops con 6 decimales)
+    let meta: i128 = 1_000_000_000;
+    let id = cliente.crear_proyecto(
+        &dueno,
+        &String::from_str(&env, "Produccion tasas reales"),
+        &meta,
+        &doc_hash_vacio(&env),
+    );
+    cliente.admin_aprobar(&id);
+    cliente.contribuir(&backer, &id, &meta);
+
+    assert_eq!(cliente.obtener_proyecto(&id).estado, EstadoProyecto::Liberado);
+
+    // Avanzar exactamente un año (525 600 minutos = 525 600 × 60 segundos)
+    const SEGUNDOS_ANO: u64 = 525_600 * 60;
+    env.ledger().with_mut(|l| l.timestamp = SEGUNDOS_ANO);
+
+    let detalle = cliente.calcular_yield_detallado(&id);
+
+    // 500 MXNe a 9.45 % ≈ 47.25 MXNe → aceptamos [45, 49] MXNe
+    assert!(
+        detalle.cetes >= 45_000_000 && detalle.cetes <= 49_000_000,
+        "CETES yield anual fuera de rango esperado (~47.25 MXNe): {} stroops",
+        detalle.cetes
+    );
+
+    // 500 MXNe a 4.00 % ≈ 20.00 MXNe → aceptamos [18, 22] MXNe
+    assert!(
+        detalle.amm >= 18_000_000 && detalle.amm <= 22_000_000,
+        "AMM yield anual fuera de rango esperado (~20.00 MXNe): {} stroops",
+        detalle.amm
+    );
+
+    // El total debe ser la suma exacta de ambas partes
+    assert_eq!(detalle.total, detalle.cetes + detalle.amm);
+}
+
+/// Confirma que el yield a 1 año NO alcanza las magnitudes de las antiguas tasas demo
+/// (CETES 25 000 bps ≈ 2 500 MXNe, AMM 10 000 bps ≈ 1 000 MXNe sobre 500 MXNe).
+#[test]
+fn test_yield_no_es_demo_exagerado() {
+    let (env, cliente, _admin, dueno, backer) = setup();
+
+    let meta: i128 = 1_000_000_000;
+    let id = cliente.crear_proyecto(
+        &dueno,
+        &String::from_str(&env, "Anti-demo check"),
+        &meta,
+        &doc_hash_vacio(&env),
+    );
+    cliente.admin_aprobar(&id);
+    cliente.contribuir(&backer, &id, &meta);
+
+    const SEGUNDOS_ANO: u64 = 525_600 * 60;
+    env.ledger().with_mut(|l| l.timestamp = SEGUNDOS_ANO);
+
+    let detalle = cliente.calcular_yield_detallado(&id);
+
+    // Con 25 000 bps, 500 MXNe produciría ~1 250 MXNe — muy por encima del límite sano
+    assert!(detalle.cetes < 100_000_000, "CETES yield parece estar usando tasa demo: {} stroops", detalle.cetes);
+    assert!(detalle.amm   < 100_000_000, "AMM yield parece estar usando tasa demo: {} stroops", detalle.amm);
 }


### PR DESCRIPTION
Closes #3

Cambios en bimex/contracts/bimex/src/lib.rs

Añade DEFAULT_CETES_BPS = 945 y DEFAULT_AMM_BPS = 400 como constantes nombradas
Reemplaza los tres unwrap_or(25000) / unwrap_or(10000) hardcodeados en calcular_yield, calcular_yield_detallado y reclamar_yield con las nuevas constantes
Cambios en bimex/contracts/bimex/src/test.rs

setup() y test_flujo_completo ahora inicializan el contrato con 945 / 400 bps
test_yield_tasas_reales_produccion: contribución de 1 000 MXNe, avance de 1 año → verifica CETES ≈ 47 MXNe y AMM ≈ 20 MXNe (±2 MXNe por truncamiento entero)
test_yield_no_es_demo_exagerado: confirma que el yield anual no supera 100 MXNe, descartando regresión a las tasas demo (~250× mayores)
Frontend (bimex-frontend/src/stellar/contrato.js): ya tiene _isMainnet ? 945 : 5000000 — sin cambios necesarios