### PR TITLE
fix(navbar): fix landing navbar overflow on mobile

### DIFF
--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -290,8 +290,8 @@ function Landing({ autoConectar, onConectado }) {
           <span style={st.navbarLogo}>Bimex</span>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-          <span style={st.testnetBadgeDark}>⚡ Testnet</span>
-          <ConectarWallet autoConectar={autoConectar} onConectado={onConectado} />
+          <span className="navbar-hide-tablet" style={st.testnetBadgeDark}>⚡ Testnet</span>
+          <ConectarWallet autoConectar={autoConectar} onConectado={onConectado} inNavbar />
         </div>
       </nav>
 
@@ -451,7 +451,7 @@ function Landing({ autoConectar, onConectado }) {
 const st = {
   navbar: {
     display: "flex", alignItems: "center", justifyContent: "space-between",
-    padding: "0 48px", height: 64,
+    padding: "0 clamp(14px, 4vw, 48px)", height: 64,
     background: "linear-gradient(135deg, #1E0A3C 0%, #2D1B69 100%)",
     position: "fixed", top: 0, left: 0, right: 0, zIndex: 50,
     boxShadow: "0 2px 20px rgba(28,22,51,0.22)",

--- a/bimex-frontend/src/components/ConectarWallet.jsx
+++ b/bimex-frontend/src/components/ConectarWallet.jsx
@@ -4,7 +4,7 @@ import {
 } from "@stellar/freighter-api";
 import { CONFIG } from "../stellar/contrato";
 
-export default function ConectarWallet({ onConectado, autoConectar = true }) {
+export default function ConectarWallet({ onConectado, autoConectar = true, inNavbar = false }) {
   const [estado, setEstado] = useState("inactivo");
   const [direccion, setDireccion] = useState(null);
   const [error, setError] = useState("");
@@ -42,9 +42,9 @@ export default function ConectarWallet({ onConectado, autoConectar = true }) {
   }
 
   if (estado === "conectado") return (
-    <div style={{ display: "flex", alignItems: "center", gap: 8, background: "var(--primary-dim)", border: "1.5px solid rgba(124,58,237,0.25)", padding: "10px 18px", borderRadius: 99 }}>
+    <div style={{ display: "flex", alignItems: "center", gap: 8, background: "var(--primary-dim)", border: "1.5px solid rgba(124,58,237,0.25)", padding: inNavbar ? "6px 14px" : "10px 18px", borderRadius: 99 }}>
       <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--primary)", boxShadow: "0 0 6px rgba(124,58,237,0.5)", flexShrink: 0 }} />
-      <span style={{ fontFamily: "DM Mono, monospace", fontSize: 14, color: "var(--primary)" }}>
+      <span style={{ fontFamily: "DM Mono, monospace", fontSize: inNavbar ? 12 : 14, color: "var(--primary)" }}>
         {direccion.slice(0, 4)}…{direccion.slice(-4)}
       </span>
     </div>
@@ -61,21 +61,22 @@ export default function ConectarWallet({ onConectado, autoConectar = true }) {
             : "linear-gradient(135deg, #7C3AED, #6D28D9)",
           color: "#fff",
           border: "none",
-          padding: "14px 40px",
-          borderRadius: 12,
+          padding: inNavbar ? "8px 18px" : "14px 40px",
+          borderRadius: inNavbar ? 99 : 12,
           fontFamily: "Syne, sans-serif",
           fontWeight: 700,
-          fontSize: 16,
+          fontSize: inNavbar ? 13 : 16,
           cursor: estado === "verificando" ? "not-allowed" : "pointer",
           boxShadow: "0 4px 20px rgba(124,58,237,0.35)",
           transition: "all 0.18s",
           letterSpacing: "-0.01em",
+          whiteSpace: "nowrap",
         }}
       >
-        {estado === "verificando" ? "Conectando…" : "Conectar con Freighter"}
+        {estado === "verificando" ? "Conectando…" : inNavbar ? "Conectar" : "Conectar con Freighter"}
       </button>
 
-      {estado === "sin_extension" && (
+      {!inNavbar && estado === "sin_extension" && (
         <p style={{ color: "var(--amber)", fontSize: 13, margin: 0, textAlign: "center" }}>
           Freighter no está instalado.{" "}
           <a href="https://freighter.app" target="_blank" rel="noreferrer"
@@ -84,12 +85,12 @@ export default function ConectarWallet({ onConectado, autoConectar = true }) {
           </a>
         </p>
       )}
-      {estado === "red_incorrecta" && (
+      {!inNavbar && estado === "red_incorrecta" && (
         <p style={{ color: "var(--amber)", fontSize: 13, margin: 0 }}>
           Cambia Freighter a <strong>Test Net</strong>
         </p>
       )}
-      {estado === "error" && (
+      {!inNavbar && estado === "error" && (
         <p style={{ color: "var(--error)", fontSize: 13, margin: 0 }}>{error}</p>
       )}
     </div>


### PR DESCRIPTION
- Use clamp(14px, 4vw, 48px) padding in st.navbar so it shrinks on mobile
- Add inNavbar prop to ConectarWallet: compact button (padding 8/18px, font 13px, text "Conectar", border-radius 99)
- Hide TESTNET badge below 860px in landing navbar via navbar-hide-tablet class

https://claude.ai/code/session_01JfnhH2CghRyxav22rfM8bQ