### PR TITLE
fix: hardening completo — BigInt, accesibilidad, UX y tests

### DIFF
--- a/bimex-frontend/package-lock.json
+++ b/bimex-frontend/package-lock.json
@@ -25,20 +25,76 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "vite": "^8.0.1"
+        "jsdom": "^29.1.1",
+        "vite": "^8.0.1",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -291,6 +347,169 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -480,6 +699,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -943,6 +1180,13 @@
         }
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stellar/freighter-api": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
@@ -1117,6 +1361,48 @@
         "yarn": ">=1"
       }
     },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1127,6 +1413,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1203,6 +1507,160 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -1308,6 +1766,45 @@
         "util": "^0.12.5"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1387,6 +1884,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -1700,6 +2207,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1906,6 +2423,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -1919,6 +2450,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1937,6 +2482,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2086,6 +2638,19 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2103,6 +2668,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2370,6 +2942,16 @@
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2751,6 +3333,26 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -2989,6 +3591,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3056,6 +3665,45 @@
         "node": ">=10"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3074,6 +3722,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3458,6 +4157,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3477,6 +4217,13 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
@@ -3718,6 +4465,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3807,6 +4565,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -3836,6 +4607,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pbkdf2": {
@@ -4141,6 +4919,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -4319,6 +5107,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4479,6 +5280,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4488,6 +5296,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -4571,6 +5393,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -4581,6 +5410,23 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -4599,6 +5445,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -4619,6 +5495,32 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -4657,6 +5559,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4853,6 +5765,96 @@
         "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -4866,6 +5868,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -4905,6 +5955,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4935,6 +6002,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/bimex-frontend/package.json
+++ b/bimex-frontend/package.json
@@ -8,6 +8,9 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "coverage": "vitest run --coverage",
     "postinstall": "node scripts/fix-freighter-tsconfig.mjs"
   },
   "dependencies": {
@@ -27,13 +30,18 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.1"
+    "jsdom": "^29.1.1",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.5"
   }
 }

--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -8,6 +8,7 @@ import DetalleProyecto  from "./components/DetalleProyecto";
 import MiCuenta         from "./components/MiCuenta";
 import AdminPanel       from "./components/AdminPanel";
 import Recompensas      from "./components/Recompensas";
+import Transparencia    from "./components/Transparencia";
 import { getStorage }   from "./utils/storage";
 import { parsearError } from "./utils/errores";
 import { obtenerTodosLosProyectos, stroopsAMXNe, mintearMXNePrueba } from "./stellar/contrato";
@@ -66,18 +67,30 @@ const PASOS = [
 ];
 
 // ── Hook: estadísticas en vivo ─────────────────────────────────────────────
+let _statsCache = null;
+let _statsCacheTs = 0;
+
 function useLiveStats() {
-  const [stats, setStats] = useState({ totalProyectos: "—", totalBloqueado: "—", enProgreso: "—" });
+  const [stats, setStats] = useState(() => _statsCache ?? { totalProyectos: "—", totalBloqueado: "—", enProgreso: "—" });
   useEffect(() => {
+    if (_statsCache && Date.now() - _statsCacheTs < 15_000) {
+      setStats(_statsCache);
+      return;
+    }
     obtenerTodosLosProyectos()
       .then(proyectos => {
-        const totalBloqueado = proyectos.reduce((s, p) => s + BigInt(p.aportado ?? 0), BigInt(0));
+        const totalBloqueado = proyectos.reduce((s, p) => {
+          try { return s + BigInt(p.aportado ?? 0); } catch { return s; }
+        }, BigInt(0));
         const enProgreso = proyectos.filter(p => p.estado === "EnProgreso").length;
-        setStats({
+        const next = {
           totalProyectos: proyectos.length.toString(),
           totalBloqueado: stroopsAMXNe(totalBloqueado),
           enProgreso: enProgreso.toString(),
-        });
+        };
+        _statsCache = next;
+        _statsCacheTs = Date.now();
+        setStats(next);
       })
       .catch(() => {});
   }, []);
@@ -199,6 +212,7 @@ export default function App() {
   const [proyectoActivo, setProyectoActivo] = useState(null);
   const [modalCrear,     setModalCrear]     = useState(false);
   const [vistaActual,    setVistaActual]    = useState("proyectos");
+  const [mostrandoTransparencia, setMostrandoTransparencia] = useState(false);
   const [adminPanel,     setAdminPanel]     = useState(false);
   const [autoConectar,   setAutoConectar]   = useState(leerAutoConectarInicial);
   const [cerrandoSesion, setCerrandoSesion] = useState(false);
@@ -241,11 +255,16 @@ export default function App() {
 
   async function cerrarSesionWallet() {
     setCerrandoSesion(true);
-    try { await setAllowed(false); } catch {}
+    try {
+      await Promise.race([
+        setAllowed(false),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 4000)),
+      ]);
+    } catch {}
     finally { desconectarLocal(); setCerrandoSesion(false); }
   }
 
-  function manejarConectado(addr) {
+  const manejarConectado = useCallback((addr) => {
     if (addr) {
       storageSesion.setItem(KEY_SESION_WALLET, "1");
       setDireccion(addr);
@@ -253,12 +272,15 @@ export default function App() {
     } else {
       desconectarLocal();
     }
-  }
+  }, []);
 
   function refrescarLista() { setRefrescar(r => r + 1); }
 
+  if (mostrandoTransparencia) {
+    return <Transparencia onVolver={() => setMostrandoTransparencia(false)} />;
+  }
   if (!direccion) {
-    return <Landing autoConectar={autoConectar} onConectado={manejarConectado} />;
+    return <Landing autoConectar={autoConectar} onConectado={manejarConectado} onTransparencia={() => setMostrandoTransparencia(true)} />;
   }
 
   return (
@@ -292,6 +314,16 @@ export default function App() {
               }}
             >
               {t("nav.myAccount")}
+            </button>
+            <button
+              onClick={() => { setProyectoActivo(null); setVistaActual("transparencia"); }}
+              style={{
+                ...st.navTab,
+                color: vistaActual === "transparencia" && !proyectoActivo ? "var(--navy)" : "var(--muted)",
+                borderBottom: vistaActual === "transparencia" && !proyectoActivo ? "2px solid var(--navy)" : "2px solid transparent",
+              }}
+            >
+              {t("nav.transparency")}
             </button>
           </div>
         </div>
@@ -336,6 +368,7 @@ export default function App() {
             direccion={direccion}
             onCerrar={() => { setProyectoActivo(null); refrescarLista(); }}
             onError={mostrarError}
+            onToast={(msg) => agregarToast(msg, "success")}
           />
         ) : (
           <>
@@ -346,6 +379,9 @@ export default function App() {
                 refrescar={refrescar}
                 onError={mostrarError}
               />
+            )}
+            {vistaActual === "transparencia" && (
+              <Transparencia />
             )}
             {vistaActual === "micuenta" && (
               <MiCuenta
@@ -379,14 +415,14 @@ export default function App() {
 }
 
 // ── Landing ──────────────────────────────────────────────────────────────────
-function Landing({ autoConectar, onConectado }) {
+function Landing({ autoConectar, onConectado, onTransparencia }) {
   const liveStats = useLiveStats();
-  const { rate: cetesRate } = useCetesRate();
+  const { rate: cetesRate, error: cetesError } = useCetesRate();
 
   const STATS_LIVE = [
     { valor: liveStats.totalProyectos, label: "Proyectos activos" },
     { valor: liveStats.totalBloqueado, label: "MXNe invertidos" },
-    { valor: cetesRate ? `${cetesRate}%` : "9.45%", label: "APY CETES hoy" },
+    { valor: cetesRate ? `${cetesRate}%` : "9.45%", label: cetesError ? "APY CETES (ref.)" : "APY CETES hoy" },
   ];
 
   return (
@@ -401,6 +437,12 @@ function Landing({ autoConectar, onConectado }) {
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <span className="navbar-hide-tablet" style={st.testnetBadge}>Testnet</span>
+          <button
+            onClick={onTransparencia}
+            style={{ background: "none", border: "none", cursor: "pointer", fontSize: "0.84rem", fontWeight: 500, color: "var(--navy)", padding: "8px 12px" }}
+          >
+            Transparencia
+          </button>
           <ConectarWallet autoConectar={autoConectar} onConectado={onConectado} inNavbar />
         </div>
       </nav>

--- a/bimex-frontend/src/components/AdminPanel.jsx
+++ b/bimex-frontend/src/components/AdminPanel.jsx
@@ -6,6 +6,7 @@ import {
   rechazarProyecto,
   stroopsAMXNe,
 } from "../stellar/contrato";
+import { parsearError } from "../utils/errores.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -24,14 +25,6 @@ function docHashHex(docHash) {
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
   return hex.slice(0, 16) + "…";
-}
-
-function mensajeCorto(err) {
-  const msg = err?.message || "Error inesperado.";
-  if (msg.includes("HostError") || msg.includes("XDR") || msg.length > 120) {
-    return "Contract error. Please try again.";
-  }
-  return msg;
 }
 
 // ─── SVG Icons ────────────────────────────────────────────────────────────────
@@ -86,7 +79,7 @@ export default function AdminPanel({ direccion, adminAddress, onCerrar }) {
       const todos = await obtenerTodosLosProyectos();
       setProyectos(todos.filter((p) => p.estado === "EnRevision"));
     } catch (err) {
-      mostrarToast(t("admin.errLoad", { msg: mensajeCorto(err) }), "error");
+      mostrarToast(parsearError(err), "error");
     }
     setCargando(false);
   }
@@ -147,7 +140,7 @@ export default function AdminPanel({ direccion, adminAddress, onCerrar }) {
       mostrarToast(t("admin.toastApproved", { id: idProyecto }));
       await cargarPendientes();
     } catch (err) {
-      mostrarToast(mensajeCorto(err), "error");
+      mostrarToast(parsearError(err), "error");
     }
   }
 
@@ -176,25 +169,20 @@ export default function AdminPanel({ direccion, adminAddress, onCerrar }) {
   }
 
   async function confirmarRechazo(idProyecto) {
-    const estado = rechazando[idProyecto];
-    if (!estado) return;
+    const estadoActual = rechazando[idProyecto];
+    if (!estadoActual || !estadoActual.motivo.trim()) return;
 
-    setRechazando((prev) => ({
-      ...prev,
-      [idProyecto]: { ...prev[idProyecto], enviando: true },
-    }));
+    const motivo = estadoActual.motivo;
+    setRechazando((prev) => ({ ...prev, [idProyecto]: { ...prev[idProyecto], enviando: true } }));
 
     try {
-      await rechazarProyecto(direccion, idProyecto, estado.motivo);
+      await rechazarProyecto(direccion, idProyecto, motivo);
       mostrarToast(t("admin.toastRejected", { id: idProyecto }));
       cancelarRechazo(idProyecto);
       await cargarPendientes();
     } catch (err) {
-      mostrarToast(mensajeCorto(err), "error");
-      setRechazando((prev) => ({
-        ...prev,
-        [idProyecto]: { ...prev[idProyecto], enviando: false },
-      }));
+      mostrarToast(parsearError(err), "error");
+      setRechazando((prev) => ({ ...prev, [idProyecto]: { ...prev[idProyecto], enviando: false } }));
     }
   }
 

--- a/bimex-frontend/src/components/ConectarWallet.jsx
+++ b/bimex-frontend/src/components/ConectarWallet.jsx
@@ -3,6 +3,7 @@ import {
   isConnected, isAllowed, requestAccess, getAddress, getNetwork,
 } from "@stellar/freighter-api";
 import { CONFIG } from "../stellar/contrato";
+import { parsearError } from "../utils/errores.js";
 
 export default function ConectarWallet({ onConectado, autoConectar = true, inNavbar = false }) {
   const [estado,    setEstado]    = useState("inactivo");
@@ -32,11 +33,17 @@ export default function ConectarWallet({ onConectado, autoConectar = true, inNav
       if (!conectado) { setEstado("sin_extension"); return; }
       await requestAccess();
       const { networkPassphrase } = await getNetwork();
+      if (!networkPassphrase) { setError("Freighter no devolvió la red activa. Asegúrate de que esté desbloqueado."); setEstado("error"); return; }
       if (networkPassphrase !== CONFIG.NETWORK_PASSPHRASE) { setEstado("red_incorrecta"); return; }
       const { address } = await getAddress();
+      if (!address || address.length < 10) {
+        setError("No se pudo obtener la dirección de la wallet. Intenta de nuevo.");
+        setEstado("error");
+        return;
+      }
       setDireccion(address); setEstado("conectado"); onConectado?.(address);
     } catch (e) {
-      setError(e.message || "Error al conectar");
+      setError(parsearError(e));
       setEstado("error");
     }
   }
@@ -54,7 +61,7 @@ export default function ConectarWallet({ onConectado, autoConectar = true, inNav
         background: "var(--green)", flexShrink: 0,
       }} />
       <span style={{ fontFamily: "monospace", fontSize: inNavbar ? 12 : 14, color: "var(--navy)", fontWeight: 600 }}>
-        {direccion.slice(0, 4)}…{direccion.slice(-4)}
+        {direccion && direccion.length >= 8 ? `${direccion.slice(0, 4)}…${direccion.slice(-4)}` : direccion}
       </span>
     </div>
   );

--- a/bimex-frontend/src/components/CrearProyecto.jsx
+++ b/bimex-frontend/src/components/CrearProyecto.jsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { parsearError } from "../utils/errores.js";
 import {
   crearProyecto as crearProyectoContrato,
   mxneAStroops,
@@ -137,7 +138,34 @@ function Stepper({ pasos, pasoActual }) {
 
 export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }) {
   const { t } = useTranslation();
+  const modalRef = useRef(null);
+  const botonAbrioRef = useRef(document.activeElement);
   const [paso, setPaso] = useState(1);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal) return;
+    modal.focus();
+    function onKeyDown(e) {
+      if (e.key === "Escape") { onCerrar(); return; }
+      if (e.key !== "Tab") return;
+      const focusables = modal.querySelectorAll(
+        'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      const primero = focusables[0];
+      const ultimo  = focusables[focusables.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === primero) { e.preventDefault(); ultimo?.focus(); }
+      } else {
+        if (document.activeElement === ultimo)  { e.preventDefault(); primero?.focus(); }
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      botonAbrioRef.current?.focus?.();
+    };
+  }, [onCerrar]);
 
   const PASOS = [
     { n: 1, label: t("crear.step1") },
@@ -170,9 +198,11 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
   function manejarCambio(e) {
     const { name, value } = e.target;
     if (name === "meta") {
-      // Solo dígitos — guarda el número crudo
       const raw = value.replace(/[^0-9]/g, "");
       setForma({ ...forma, meta: raw });
+    } else if (name === "tiempoMeses") {
+      const n = parseInt(value, 10);
+      setForma({ ...forma, tiempoMeses: isNaN(n) ? "" : String(Math.min(120, Math.max(1, n))) });
     } else {
       setForma({ ...forma, [name]: value });
     }
@@ -225,7 +255,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
       setPaso(3);
     } catch (err) {
       onError?.(err);
-      setError(t("crear.errHash"));
+      setError(parsearError(err));
     }
     setHasheando(false);
   }
@@ -240,7 +270,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
       await crearProyectoContrato(direccion, forma.nombre, metaStroops, docCid);
       onCreado();
     } catch (err) {
-      console.error("Error al crear proyecto:", err);
+      setError(parsearError(err));
       onError?.(err);
     }
     setCargando(false);
@@ -265,6 +295,8 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
         aria-labelledby="crear-titulo"
         style={{ maxWidth: "540px" }}
         onClick={(e) => e.stopPropagation()}
+        ref={modalRef}
+        tabIndex={-1}
       >
         {/* Header */}
         <div className="modal-header">
@@ -566,6 +598,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
 
 // ── Componente: Campo de documento ───────────────────────────────────────────
 function CampoDocumento({ id, label, descripcion, accept, icono, archivo, onChange, selectLabel, maxSizeLabel }) {
+  const [sizeError, setSizeError] = useState(false);
   return (
     <div style={estilos.campoDoc}>
       <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
@@ -599,8 +632,18 @@ function CampoDocumento({ id, label, descripcion, accept, icono, archivo, onChan
             type="file"
             accept={accept}
             style={{ display: "none" }}
-            onChange={e => onChange(e.target.files?.[0] ?? null)}
+            onChange={e => {
+              const f = e.target.files?.[0] ?? null;
+              if (f && f.size > 10_000_000) { e.target.value = ""; setSizeError(true); onChange(null); return; }
+              setSizeError(false);
+              onChange(f);
+            }}
           />
+          {sizeError && (
+            <p style={{ fontSize: "0.74rem", color: "#DC2626", marginTop: 6 }}>
+              El archivo supera el límite de 10 MB.
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/bimex-frontend/src/components/DetalleProyecto.jsx
+++ b/bimex-frontend/src/components/DetalleProyecto.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { parsearError } from "../utils/errores.js";
 import {
   contribuir as contribuirContrato,
   retirarPrincipal as retirarPrincipalContrato,
@@ -71,18 +72,19 @@ const IconShield = () => (
   </svg>
 );
 
-export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, onCerrar, onError }) {
+export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, onCerrar, onError, onToast }) {
   const { t } = useTranslation();
+  const montadoRef = useRef(true);
+  useEffect(() => () => { montadoRef.current = false; }, []);
   const [proyecto,          setProyecto]          = useState(proyectoInicial);
   const [cantidad,          setCantidad]          = useState("");
   const [cargando,          setCargando]          = useState(false);
   const [modoInversion,     setModoInversion]     = useState("inversor");
   const [vistaRetirar,      setVistaRetirar]      = useState(false);
   const [confirmarAbandonar,setConfirmarAbandonar]= useState(false);
-  const [toast,             setToast]             = useState(null);
   const [miAportacion,      setMiAportacion]      = useState(BigInt(0));
   const [miYield,           setMiYield]           = useState(BigInt(0));
-  const [balanceMXNe,       setBalanceMXNe]       = useState(BigInt(0));
+  const [balanceMXNe,       setBalanceMXNe]       = useState(null);
 
   const estado    = proyecto.estado ?? "EtapaInicial";
   const estadoCfg = ESTADO_CONFIG[estado] ?? ESTADO_CONFIG.EtapaInicial;
@@ -113,14 +115,17 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
         obtenerProyecto(proyecto.id).catch(() => null),
         obtenerAportacion(proyecto.id, direccion).catch(() => BigInt(0)),
         calcularYield(proyecto.id, direccion).catch(() => BigInt(0)),
-        obtenerBalanceMXNe(direccion).catch(() => BigInt(0)),
+        obtenerBalanceMXNe(direccion).catch(() => null),
       ]);
+      if (!montadoRef.current) return;
       if (proyActualizado) setProyecto(proyActualizado);
       setMiAportacion(aport);
       setMiYield(yld);
       setBalanceMXNe(bal);
-    } catch { /* ignore */ }
-  }, [proyecto.id, direccion]);
+    } catch (e) {
+      if (montadoRef.current) onError?.(parsearError(e));
+    }
+  }, [proyecto.id, direccion, onError]);
 
   useEffect(() => { refrescar(); }, [refrescar]);
 
@@ -130,11 +135,6 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [onCerrar]);
-
-  function mostrarToast(msg, tipo = "success") {
-    setToast({ msg, tipo });
-    setTimeout(() => setToast(null), 4500);
-  }
 
   function mensajeCorto(err) {
     const msg = err?.message || t("detalle.errContract");
@@ -148,9 +148,9 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     setCantidad(raw);
   }
 
-  const cantidadNum   = Number(cantidad);
+  const cantidadNum    = Number(cantidad);
   const cantidadValida = cantidad !== "" && !isNaN(cantidadNum) && cantidadNum > 0;
-  const superaBalance  = cantidadValida && mxneAStroops(cantidadNum) > balanceMXNe;
+  const superaBalance  = cantidadValida && balanceMXNe !== null && mxneAStroops(cantidadNum) > balanceMXNe;
   const errorCantidad  = !cantidadValida && cantidad !== ""
     ? t("detalle.errAmount")
     : superaBalance
@@ -164,7 +164,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     setCargando(true);
     try {
       await contribuirContrato(direccion, proyecto.id, mxneAStroops(Number(cantidad)));
-      mostrarToast(t("detalle.toastContributed", { amount: cantidad }));
+      onToast?.(t("detalle.toastContributed", { amount: cantidad }));
       setCantidad("");
       await refrescar();
     } catch (err) {
@@ -177,7 +177,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     setCargando(true);
     try {
       await retirarPrincipalContrato(direccion, proyecto.id);
-      mostrarToast(t("detalle.toastWithdrawn", { amount: stroopsAMXNe(miAportacion) }));
+      onToast?.(t("detalle.toastWithdrawn", { amount: stroopsAMXNe(miAportacion) }));
       setMiAportacion(BigInt(0));
       setMiYield(BigInt(0));
       setVistaRetirar(false);
@@ -189,12 +189,12 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   }
 
   async function manejarReclamarYield() {
-    if (estado !== "Liberado") { mostrarToast(t("detalle.errYieldOnly"), "error"); return; }
-    if (yieldDueno === BigInt(0)) { mostrarToast(t("detalle.errNoYield"), "error"); return; }
+    if (estado !== "Liberado") { onError?.(t("detalle.errYieldOnly")); return; }
+    if (miYield === BigInt(0)) { onError?.(t("detalle.errNoYield")); return; }
     setCargando(true);
     try {
       await reclamarYieldContrato(direccion, proyecto.id);
-      mostrarToast(t("detalle.toastYield"));
+      onToast?.(t("detalle.toastYield"));
       await refrescar();
     } catch (err) {
       onError?.(err);
@@ -207,7 +207,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     setCargando(true);
     try {
       await abandonarProyectoContrato(direccion, proyecto.id);
-      mostrarToast(t("detalle.toastAbandoned"));
+      onToast?.(t("detalle.toastAbandoned"));
       await refrescar();
     } catch (err) {
       onError?.(err);
@@ -219,7 +219,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     setCargando(true);
     try {
       await solicitarContinuarContrato(direccion, proyecto.id);
-      mostrarToast(t("detalle.toastContinued"));
+      onToast?.(t("detalle.toastContinued"));
       await refrescar();
     } catch (err) {
       onError?.(err);
@@ -307,17 +307,17 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
               <div className="split-table">
                 <div className="split-row">
                   <span className="split-name" style={{ color: "var(--green)", fontWeight: 600 }}>{t("detalle.splitProject")}</span>
-                  <div className="split-bar-wrap"><div className="split-bar" style={{ width: "44.6%", background: "var(--green)" }} /></div>
+                  <div className="split-bar-wrap" role="progressbar" aria-valuenow={45} aria-valuemin={0} aria-valuemax={100} aria-valuetext="6.00%"><div className="split-bar" style={{ width: "44.6%", background: "var(--green)" }} /></div>
                   <span className="split-pct" style={{ color: "var(--green)" }}>6.00%</span>
                 </div>
                 <div className="split-row">
                   <span className="split-name" style={{ color: "var(--navy)", fontWeight: 600 }}>{t("detalle.splitInvestor")}</span>
-                  <div className="split-bar-wrap"><div className="split-bar" style={{ width: "37.2%", background: "var(--navy)" }} /></div>
+                  <div className="split-bar-wrap" role="progressbar" aria-valuenow={37} aria-valuemin={0} aria-valuemax={100} aria-valuetext="5.00%"><div className="split-bar" style={{ width: "37.2%", background: "var(--navy)" }} /></div>
                   <span className="split-pct" style={{ color: "var(--navy)" }}>5.00%</span>
                 </div>
                 <div className="split-row" style={{ background: "var(--bg)" }}>
                   <span className="split-name" style={{ color: "var(--muted)" }}>{t("detalle.splitPlatform")}</span>
-                  <div className="split-bar-wrap"><div className="split-bar" style={{ width: "18.2%", background: "var(--subtle)" }} /></div>
+                  <div className="split-bar-wrap" role="progressbar" aria-valuenow={18} aria-valuemin={0} aria-valuemax={100} aria-valuetext="2.45%"><div className="split-bar" style={{ width: "18.2%", background: "var(--subtle)" }} /></div>
                   <span className="split-pct" style={{ color: "var(--muted)" }}>2.45%</span>
                 </div>
                 <div style={{ padding: "12px 18px", background: "var(--bg)", borderTop: "2px solid var(--border)", display: "flex", justifyContent: "space-between", fontSize: "0.82rem" }}>
@@ -401,7 +401,14 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                       {stroopsAMXNe(proyecto.meta ?? 0)}
                     </span>
                   </div>
-                  <div className="progress-section__bar">
+                  <div
+                    className="progress-section__bar"
+                    role="progressbar"
+                    aria-valuenow={Math.round(porcentaje)}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuetext={`${porcentaje.toFixed(0)}%`}
+                  >
                     <div className="progress-section__fill" style={{ width: `${porcentaje}%` }} />
                   </div>
                   <div className="progress-meta">
@@ -442,6 +449,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                       <button
                         className={`mode-btn${modoInversion === "inversor" ? " active" : ""}`}
                         onClick={() => setModoInversion("inversor")}
+                        aria-pressed={modoInversion === "inversor"}
                       >
                         <h4>{t("detalle.modeInversor")}</h4>
                         <p>{t("detalle.modeInversorDesc")}</p>
@@ -449,6 +457,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                       <button
                         className={`mode-btn${modoInversion === "mecenas" ? " active" : ""}`}
                         onClick={() => setModoInversion("mecenas")}
+                        aria-pressed={modoInversion === "mecenas"}
                       >
                         <h4>{t("detalle.modeMecenas")}</h4>
                         <p>{t("detalle.modeMecenasDesc")}</p>
@@ -474,7 +483,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                           {errorCantidad}
                         </p>
                       )}
-                      {cantidadValida && !superaBalance && (
+                      {cantidadValida && !superaBalance && balanceMXNe !== null && (
                         <p style={{ fontSize: "0.75rem", color: "var(--muted)", marginTop: 5 }}>
                           {t("detalle.available")}: {stroopsAMXNe(balanceMXNe)}
                         </p>
@@ -565,14 +574,14 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                   </>
                 )}
 
-                {/* Reclamar yield (dueño) */}
-                {esDueno && !esAbandonado && BigInt(proyecto.aportado ?? 0) > BigInt(0) && (
+                {/* Reclamar yield (dueño, solo cuando proyecto liberado) */}
+                {esDueno && estado === "Liberado" && BigInt(proyecto.aportado ?? 0) > BigInt(0) && (
                   <button
                     className="btn btn-secondary"
                     style={{ width: "100%", justifyContent: "center", marginTop: 8 }}
                     onClick={manejarReclamarYield}
-                    disabled={cargando || yieldDueno === BigInt(0)}
-                    title={yieldDueno === BigInt(0) ? t("detalle.waitYield") : ""}
+                    disabled={cargando || miYield === BigInt(0)}
+                    title={miYield === BigInt(0) ? t("detalle.waitYield") : ""}
                   >
                     {cargando ? t("detalle.processing") : t("detalle.claimYield")}
                   </button>
@@ -597,16 +606,6 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
         </div>
       </div>
 
-      {toast && (
-        <div
-          className={`toast ${toast.tipo}`}
-          role={toast.tipo === "error" ? "alert" : "status"}
-          aria-live={toast.tipo === "error" ? "assertive" : "polite"}
-          aria-atomic="true"
-        >
-          {toast.msg}
-        </div>
-      )}
     </>
   );
 }

--- a/bimex-frontend/src/components/ListaProyectos.jsx
+++ b/bimex-frontend/src/components/ListaProyectos.jsx
@@ -1,12 +1,16 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { obtenerTodosLosProyectos, stroopsAMXNe } from "../stellar/contrato";
+import { parsearError } from "../utils/errores.js";
 
 export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
   const { t } = useTranslation();
   const [proyectos, setProyectos] = useState([]);
   const [cargando, setCargando] = useState(true);
   const [filtro, setFiltro] = useState("Todos");
+  const [visibles, setVisibles] = useState(12);
+  const [errorCarga, setErrorCarga] = useState(null);
+  const cargandoRef = useRef(false);
 
   const ESTADOS_OCULTOS = new Set(["EnRevision", "Rechazado"]);
   const FILTROS = [
@@ -18,21 +22,28 @@ export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
   ];
 
   async function cargar() {
+    if (cargandoRef.current) return;
+    cargandoRef.current = true;
     setCargando(true);
+    setErrorCarga(null);
     try {
       const data = await obtenerTodosLosProyectos();
       setProyectos(data);
     } catch (e) {
-      console.error("[Bimex] Error cargando proyectos:", e);
+      setErrorCarga(parsearError(e));
     } finally {
       setCargando(false);
+      cargandoRef.current = false;
     }
   }
 
   useEffect(() => { cargar(); }, [refrescar]);
+  useEffect(() => { setVisibles(12); }, [filtro]);
 
   const proyectosPublicos = proyectos.filter(p => !ESTADOS_OCULTOS.has(p.estado));
-  const totalBloqueado = proyectosPublicos.reduce((s, p) => s + BigInt(p.aportado ?? 0), BigInt(0));
+  const totalBloqueado = proyectosPublicos.reduce((s, p) => {
+    try { return s + BigInt(p.aportado ?? 0); } catch { return s; }
+  }, BigInt(0));
   const enProgreso = proyectosPublicos.filter(p => p.estado === "EnProgreso").length;
   const liberados  = proyectosPublicos.filter(p => p.estado === "Liberado").length;
 
@@ -102,6 +113,7 @@ export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
               <button
                 key={f.key}
                 onClick={() => setFiltro(f.key)}
+                aria-pressed={activo}
                 style={{
                   ...estilos.filtroBtnBase,
                   background: activo ? "var(--navy)" : "var(--card)",
@@ -129,6 +141,13 @@ export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
               </button>
             );
           })}
+        </div>
+      )}
+
+      {/* Error de carga */}
+      {errorCarga && (
+        <div className="error-mensaje" role="alert" style={{ color: "var(--error, #DC2626)", background: "rgba(220,38,38,0.06)", border: "1px solid rgba(220,38,38,0.18)", borderRadius: "var(--radius-sm)", padding: "12px 16px", fontSize: "0.86rem", marginBottom: 20 }}>
+          {errorCarga}
         </div>
       )}
 
@@ -166,11 +185,23 @@ export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
           </button>
         </div>
       ) : (
-        <div className="grid-proyectos" style={estilos.grid} role="list" aria-label={t("lista.ariaList")}>
-          {proyectosFiltrados.map((p) => (
-            <CardProyecto key={p.id} proyecto={p} onClick={() => onSeleccionar(p)} />
-          ))}
-        </div>
+        <>
+          <div className="grid-proyectos" style={estilos.grid} role="list" aria-label={t("lista.ariaList")}>
+            {proyectosFiltrados.slice(0, visibles).map((p) => (
+              <CardProyecto key={p.id} proyecto={p} onClick={() => onSeleccionar(p)} />
+            ))}
+          </div>
+          {proyectosFiltrados.length > visibles && (
+            <div style={{ display: "flex", justifyContent: "center", marginTop: 24 }}>
+              <button
+                className="btn btn-ghost"
+                onClick={() => setVisibles(v => v + 12)}
+              >
+                {t("lista.loadMore")} ({proyectosFiltrados.length - visibles} {t("lista.remaining")})
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/bimex-frontend/src/components/MiCuenta.jsx
+++ b/bimex-frontend/src/components/MiCuenta.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { createClient } from "@supabase/supabase-js";
+import { parsearError } from "../utils/errores.js";
 import {
   obtenerTodosLosProyectos,
   obtenerAportacion,
@@ -225,6 +226,7 @@ function TabMisContribuciones({ proyectos, direccion, onVerProyecto }) {
   const { t } = useTranslation();
   const [contribuciones, setContribuciones] = useState([]);
   const [cargando, setCargando] = useState(true);
+  const [errorContrib, setErrorContrib] = useState(null);
 
   useEffect(() => {
     if (proyectos.length === 0) {
@@ -234,6 +236,7 @@ function TabMisContribuciones({ proyectos, direccion, onVerProyecto }) {
 
     async function cargarContribuciones() {
       setCargando(true);
+      setErrorContrib(null);
       try {
         const resultados = await Promise.all(
           proyectos.map(async (p) => {
@@ -246,7 +249,7 @@ function TabMisContribuciones({ proyectos, direccion, onVerProyecto }) {
         );
         setContribuciones(resultados.filter((r) => r.aportacion > BigInt(0)));
       } catch (e) {
-        console.error("Error cargando contribuciones:", e);
+        setErrorContrib(parsearError(e));
       } finally {
         setCargando(false);
       }
@@ -256,6 +259,14 @@ function TabMisContribuciones({ proyectos, direccion, onVerProyecto }) {
   }, [proyectos, direccion]);
 
   if (cargando) return <Spinner />;
+
+  if (errorContrib) {
+    return (
+      <div role="alert" style={{ color: "var(--error, #DC2626)", background: "rgba(220,38,38,0.06)", border: "1px solid rgba(220,38,38,0.18)", borderRadius: "var(--radius-sm)", padding: "14px 18px", fontSize: "0.86rem", marginTop: 8 }}>
+        {errorContrib}
+      </div>
+    );
+  }
 
   if (contribuciones.length === 0) {
     return (
@@ -360,7 +371,8 @@ function NotificacionesPanel({ direccion }) {
       .then(({ data }) => {
         if (data) { setEmail(data.email); setEnabled(data.notifications_enabled); }
         setCargado(true);
-      });
+      })
+      .catch(() => setCargado(true));
   }, [direccion]);
 
   async function guardar(e) {
@@ -450,15 +462,17 @@ export default function MiCuenta({ direccion, onVerProyecto, onTotalInvertido })
   const [tab, setTab] = useState("proyectos");
   const [proyectos, setProyectos] = useState([]);
   const [cargando, setCargando] = useState(true);
+  const [errorPrincipal, setErrorPrincipal] = useState(null);
 
   useEffect(() => {
     async function cargar() {
       setCargando(true);
+      setErrorPrincipal(null);
       try {
         const data = await obtenerTodosLosProyectos();
         setProyectos(data);
       } catch (e) {
-        console.error("Error cargando proyectos:", e);
+        setErrorPrincipal(parsearError(e));
       } finally {
         setCargando(false);
       }
@@ -496,14 +510,16 @@ export default function MiCuenta({ direccion, onVerProyecto, onTotalInvertido })
         if (cancelado) return;
         const positivos = resultados.filter((r) => r.aportacion > BigInt(0));
         const total  = positivos.reduce((acc, r) => acc + r.aportacion, BigInt(0));
-        const totalY = positivos.reduce((acc, r) => acc + BigInt(r.yieldAcum ?? 0), BigInt(0));
+        const totalY = positivos.reduce((acc, r) => {
+          try { return acc + BigInt(r.yieldAcum ?? 0); } catch { return acc; }
+        }, BigInt(0));
         setNumApoyados(positivos.length);
         setTotalInvertido(total);
         setTotalYield(totalY);
         onTotalInvertido?.(total);
       } catch (e) {
-        console.error("Error calculando resumen:", e);
         if (!cancelado) {
+          setErrorPrincipal(parsearError(e));
           setNumApoyados(0);
           setTotalInvertido(BigInt(0));
           setTotalYield(BigInt(0));
@@ -513,7 +529,7 @@ export default function MiCuenta({ direccion, onVerProyecto, onTotalInvertido })
 
     calcularResumen();
     return () => { cancelado = true; };
-  }, [proyectos, direccion]);
+  }, [proyectos, direccion, onTotalInvertido]);
 
   const resumenListo = numApoyados !== null && totalInvertido !== null;
 
@@ -529,6 +545,13 @@ export default function MiCuenta({ direccion, onVerProyecto, onTotalInvertido })
           </p>
         </div>
       </div>
+
+      {/* Error principal */}
+      {errorPrincipal && (
+        <div role="alert" style={{ color: "var(--error, #DC2626)", background: "rgba(220,38,38,0.06)", border: "1px solid rgba(220,38,38,0.18)", borderRadius: "var(--radius-sm)", padding: "12px 16px", fontSize: "0.86rem", marginBottom: 20 }}>
+          {errorPrincipal}
+        </div>
+      )}
 
       {/* 3 Metric Cards */}
       <div style={estilos.metricsRow}>

--- a/bimex-frontend/src/components/Recompensas.jsx
+++ b/bimex-frontend/src/components/Recompensas.jsx
@@ -89,11 +89,13 @@ export default function Recompensas({ direccion, refrescar, totalInvertido: tota
   // Si el padre ya calculó totalInvertido, úsalo directamente
   useEffect(() => {
     if (totalInvertidoProp != null) {
-      setTotalMXNe(Number(BigInt(totalInvertidoProp)) / 10_000_000);
+      const b = typeof totalInvertidoProp === "bigint" ? totalInvertidoProp : BigInt(totalInvertidoProp ?? 0);
+      setTotalMXNe(Number(b / BigInt(10_000_000)) + Number(b % BigInt(10_000_000)) / 10_000_000);
       setCargando(false);
       return;
     }
     if (!direccion) return;
+    let cancelado = false;
     (async () => {
       setCargando(true);
       try {
@@ -101,14 +103,20 @@ export default function Recompensas({ direccion, refrescar, totalInvertido: tota
         const aportaciones = await Promise.all(
           proyectos.map(p => obtenerAportacion(p.id, direccion).catch(() => BigInt(0)))
         );
-        const totalStroops = aportaciones.reduce((s, a) => s + BigInt(a), BigInt(0));
-        setTotalMXNe(Number(totalStroops) / 10_000_000);
+        const totalStroops = aportaciones.reduce((s, a) => {
+          try { return s + BigInt(a); } catch { return s; }
+        }, BigInt(0));
+        if (!cancelado) {
+          const mxne = Number(totalStroops / BigInt(10_000_000)) + Number(totalStroops % BigInt(10_000_000)) / 10_000_000;
+          setTotalMXNe(mxne);
+        }
       } catch {
-        setTotalMXNe(0);
+        if (!cancelado) setTotalMXNe(0);
       } finally {
-        setCargando(false);
+        if (!cancelado) setCargando(false);
       }
     })();
+    return () => { cancelado = true; };
   }, [direccion, refrescar, totalInvertidoProp]);
 
   // Cierra con Escape o clic fuera

--- a/bimex-frontend/src/components/Transparencia.jsx
+++ b/bimex-frontend/src/components/Transparencia.jsx
@@ -1,0 +1,333 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { obtenerTodosLosProyectos, calcularYieldDetallado, stroopsAMXNe } from "../stellar/contrato";
+import { parsearError } from "../utils/errores.js";
+
+const ESTADOS_OCULTOS = new Set(["EnRevision", "Rechazado"]);
+
+const ESTADO_CFG = {
+  EtapaInicial: { badge: "badge-muted" },
+  EnProgreso:   { badge: "badge-teal"  },
+  Liberado:     { badge: "badge-amber" },
+  Abandonado:   { badge: "badge-red"   },
+};
+
+function StatStrip({ label, valor, mono, highlight }) {
+  return (
+    <div style={{ textAlign: "center", flex: 1 }}>
+      <div style={{ fontSize: "0.7rem", color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.07em", fontWeight: 600, marginBottom: 4 }}>
+        {label}
+      </div>
+      <div style={{
+        fontFamily: mono ? "'SFMono-Regular', 'Consolas', monospace" : "inherit",
+        fontWeight: 700, fontSize: "0.95rem",
+        color: highlight ? "var(--green)" : "var(--text2)",
+      }}>
+        {valor}
+      </div>
+    </div>
+  );
+}
+
+export default function Transparencia({ onVolver }) {
+  const { t } = useTranslation();
+  const [proyectos, setProyectos] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [errorCarga, setErrorCarga] = useState(null);
+  const [filtro, setFiltro] = useState("Todos");
+  const [totalYield, setTotalYield] = useState(BigInt(0));
+
+  const FILTROS = [
+    { key: "Todos",        label: t("filters.all")        },
+    { key: "EtapaInicial", label: t("filters.initial")    },
+    { key: "EnProgreso",   label: t("filters.inProgress") },
+    { key: "Liberado",     label: t("filters.released")   },
+    { key: "Abandonado",   label: t("filters.abandoned")  },
+  ];
+
+  async function cargar() {
+    setCargando(true);
+    setErrorCarga(null);
+    try {
+      const data = await obtenerTodosLosProyectos();
+      const publicos = data.filter(p => !ESTADOS_OCULTOS.has(p.estado));
+      setProyectos(publicos);
+
+      const yields = await Promise.all(
+        publicos.map(p => calcularYieldDetallado(p.id).catch(() => ({ total: BigInt(0) })))
+      );
+      const sumaYield = yields.reduce((s, y) => {
+        try { return s + BigInt(y?.total ?? 0); } catch { return s; }
+      }, BigInt(0));
+      setTotalYield(sumaYield);
+    } catch (e) {
+      setErrorCarga(parsearError(e));
+    } finally {
+      setCargando(false);
+    }
+  }
+
+  useEffect(() => { cargar(); }, []);
+
+  const totalBloqueado = proyectos.reduce((s, p) => {
+    try { return s + BigInt(p.aportado ?? 0); } catch { return s; }
+  }, BigInt(0));
+  const enProgreso = proyectos.filter(p => p.estado === "EnProgreso").length;
+
+  const proyectosFiltrados = filtro === "Todos"
+    ? proyectos
+    : proyectos.filter(p => p.estado === filtro);
+
+  return (
+    <div style={{ maxWidth: "1140px", margin: "0 auto", padding: "40px 24px" }}>
+
+      {onVolver && (
+        <button
+          onClick={onVolver}
+          style={{
+            background: "none", border: "none", cursor: "pointer",
+            color: "var(--navy)", fontWeight: 500, fontSize: "0.88rem",
+            padding: "0 0 20px 0", display: "block",
+          }}
+        >
+          {t("transp.back")}
+        </button>
+      )}
+
+      <div style={{ marginBottom: 28 }}>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 700, color: "var(--text)", marginBottom: 6 }}>
+          {t("transp.title")}
+        </h1>
+        <p style={{ color: "var(--muted)", fontSize: "0.88rem", marginTop: 4 }}>
+          {t("transp.subtitle")}
+        </p>
+      </div>
+
+      <div style={{
+        display: "flex", alignItems: "flex-start", gap: 12,
+        background: "var(--navy-dim)", border: "1px solid rgba(30,58,95,0.12)",
+        borderRadius: "var(--radius)", padding: "12px 16px", marginBottom: 24,
+      }}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: "var(--navy)", flexShrink: 0, marginTop: 2 }}>
+          <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+        </svg>
+        <p style={{ fontSize: "0.86rem", color: "var(--muted)", lineHeight: 1.6, margin: 0 }}>
+          <strong style={{ color: "var(--text2)" }}>{t("transp.infoTitle")}</strong>{" "}
+          {t("transp.infoDesc")}
+        </p>
+      </div>
+
+      {errorCarga && (
+        <div role="alert" style={{
+          color: "var(--error, #DC2626)", background: "rgba(220,38,38,0.06)",
+          border: "1px solid rgba(220,38,38,0.18)", borderRadius: "var(--radius-sm)",
+          padding: "12px 16px", fontSize: "0.86rem", marginBottom: 20,
+          display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12,
+        }}>
+          <span>{t("transp.errorLoad")}</span>
+          <button
+            onClick={cargar}
+            style={{
+              background: "none", border: "1px solid rgba(220,38,38,0.30)", cursor: "pointer",
+              color: "var(--error, #DC2626)", padding: "4px 12px", borderRadius: "var(--radius-sm)",
+              fontFamily: "Inter, sans-serif", fontWeight: 500, fontSize: "0.82rem", whiteSpace: "nowrap",
+            }}
+          >
+            {t("transp.retry")}
+          </button>
+        </div>
+      )}
+
+      {cargando ? (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "80px 0" }} role="status" aria-live="polite">
+          <div style={{ width: 32, height: 32, border: "2px solid var(--border)", borderTopColor: "var(--navy)", borderRadius: "50%", animation: "spin 0.7s linear infinite" }} aria-hidden="true" />
+          <p style={{ color: "var(--muted)", marginTop: 16, fontSize: "0.9rem" }}>{t("transp.loading")}</p>
+        </div>
+      ) : (
+        <>
+          {proyectos.length > 0 && (
+            <div className="stats-strip-scroll lista-stats-strip" style={{
+              display: "flex", alignItems: "center",
+              background: "var(--card)", border: "1px solid var(--border)",
+              borderRadius: "var(--radius)", padding: "16px 24px",
+              marginBottom: 20, boxShadow: "var(--shadow-sm)",
+            }}>
+              <StatStrip label={t("transp.statTotal")} valor={proyectos.length} />
+              <div style={{ width: 1, height: 28, background: "var(--border)", flexShrink: 0 }} />
+              <StatStrip label={t("transp.statLocked")} valor={stroopsAMXNe(totalBloqueado)} mono />
+              <div style={{ width: 1, height: 28, background: "var(--border)", flexShrink: 0 }} />
+              <StatStrip label={t("transp.statProgress")} valor={enProgreso} highlight />
+              <div style={{ width: 1, height: 28, background: "var(--border)", flexShrink: 0 }} />
+              <StatStrip label={t("transp.statYield")} valor={stroopsAMXNe(totalYield)} mono />
+            </div>
+          )}
+
+          {proyectos.length > 0 && (
+            <div style={{ marginBottom: 8 }}>
+              <span style={{ fontSize: "0.78rem", color: "var(--muted)", marginRight: 8 }}>
+                {t("transp.filterLabel")}
+              </span>
+            </div>
+          )}
+
+          {proyectos.length > 0 && (
+            <div className="filtros-row" style={{
+              display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 20,
+            }}>
+              {FILTROS.map(f => {
+                const activo = filtro === f.key;
+                const count = f.key === "Todos"
+                  ? proyectos.length
+                  : proyectos.filter(p => p.estado === f.key).length;
+                return (
+                  <button
+                    key={f.key}
+                    onClick={() => setFiltro(f.key)}
+                    aria-pressed={activo}
+                    style={{
+                      padding: "6px 14px", borderRadius: "var(--radius-sm)",
+                      fontFamily: "Inter, sans-serif", fontWeight: 500, fontSize: "0.82rem",
+                      cursor: "pointer", transition: "all 0.15s",
+                      display: "flex", alignItems: "center", gap: 4,
+                      background: activo ? "var(--navy)" : "var(--card)",
+                      color: activo ? "#fff" : "var(--text2)",
+                      border: `1px solid ${activo ? "var(--navy)" : "var(--border2)"}`,
+                    }}
+                  >
+                    {f.label}
+                    <span style={{
+                      background: activo ? "rgba(255,255,255,0.22)" : "var(--bg)",
+                      color: activo ? "#fff" : "var(--muted)",
+                      borderRadius: "99px", padding: "1px 7px",
+                      fontSize: "0.72rem", fontWeight: 600, marginLeft: 2,
+                    }}>
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {proyectos.length === 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "80px 0", textAlign: "center" }}>
+              <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "var(--border2)" }}>
+                <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10z"/>
+                <path d="M8 14s1.5 2 4 2 4-2 4-2"/>
+                <line x1="9" y1="9" x2="9.01" y2="9"/>
+                <line x1="15" y1="9" x2="15.01" y2="9"/>
+              </svg>
+              <p style={{ fontSize: "1rem", fontWeight: 600, color: "var(--text)", marginTop: 16 }}>
+                {t("transp.empty")}
+              </p>
+              <p style={{ fontSize: "0.85rem", color: "var(--muted)", marginTop: 6 }}>
+                {t("transp.emptyHint")}
+              </p>
+            </div>
+          ) : proyectosFiltrados.length === 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "80px 0", textAlign: "center" }}>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "var(--border2)" }}>
+                <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+              </svg>
+              <p style={{ fontSize: "1rem", fontWeight: 600, color: "var(--text)", marginTop: 16 }}>
+                {t("transp.noResults")}
+              </p>
+              <button
+                className="btn btn-ghost"
+                onClick={() => setFiltro("Todos")}
+                style={{ marginTop: 16 }}
+              >
+                {t("transp.viewAll")}
+              </button>
+            </div>
+          ) : (
+            <div className="grid-proyectos" style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(285px, 1fr))",
+              gap: 16,
+            }} role="list" aria-label={t("transp.title")}>
+              {proyectosFiltrados.map(p => (
+                <ProyectoCard key={p.id} proyecto={p} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ProyectoCard({ proyecto }) {
+  const { t } = useTranslation();
+  const meta     = Number(proyecto.meta);
+  const aportado = Number(proyecto.aportado);
+  const pct      = meta > 0 ? Math.min((aportado / meta) * 100, 100) : 0;
+  const estado   = proyecto.estado ?? "EtapaInicial";
+  const cfg      = ESTADO_CFG[estado] ?? ESTADO_CFG.EtapaInicial;
+
+  return (
+    <article
+      className="card"
+      role="listitem"
+      style={{ display: "flex", flexDirection: "column", opacity: estado === "Abandonado" ? 0.75 : 1 }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+        <span className={`badge ${cfg.badge}`}>
+          <span className="badge-dot" />
+          {t(`status.${estado}`)}
+        </span>
+        {proyecto.doc_hash && (
+          <span style={{
+            background: "var(--green-dim)", border: "1px solid rgba(22,163,74,0.20)",
+            color: "var(--green)", fontSize: "0.7rem", fontWeight: 600,
+            padding: "2px 8px", borderRadius: "99px",
+          }}>
+            {t("transp.verified")}
+          </span>
+        )}
+      </div>
+
+      <h3 style={{ fontSize: "0.98rem", fontWeight: 600, marginBottom: 4, lineHeight: 1.4, color: "var(--text)" }}>
+        {proyecto.nombre}
+      </h3>
+
+      <div style={{ marginTop: 18 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}>
+          <span style={{ fontSize: "0.78rem", color: "var(--muted)" }}>{t("transp.funding")}</span>
+          <span style={{ fontSize: "0.78rem", color: "var(--green)", fontWeight: 700 }}>
+            {pct.toFixed(0)}%
+          </span>
+        </div>
+        <div
+          className="progress-track"
+          role="progressbar"
+          aria-valuenow={Math.round(pct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={`${pct.toFixed(0)}%`}
+        >
+          <div className="progress-fill" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 14, paddingTop: 12, borderTop: "1px solid var(--border)" }}>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "0.7rem", color: "var(--subtle)", textTransform: "uppercase", letterSpacing: "0.06em", fontWeight: 600 }}>
+            {t("transp.locked")}
+          </div>
+          <div style={{ fontFamily: "'SFMono-Regular','Consolas',monospace", fontSize: "0.82rem", color: "var(--text2)", marginTop: 3, fontWeight: 600 }}>
+            {stroopsAMXNe(proyecto.aportado)}
+          </div>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "0.7rem", color: "var(--subtle)", textTransform: "uppercase", letterSpacing: "0.06em", fontWeight: 600 }}>
+            {t("transp.goal")}
+          </div>
+          <div style={{ fontFamily: "'SFMono-Regular','Consolas',monospace", fontSize: "0.82rem", color: "var(--muted)", marginTop: 3, fontWeight: 600 }}>
+            {stroopsAMXNe(proyecto.meta)}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/bimex-frontend/src/hooks/useCetesRate.js
+++ b/bimex-frontend/src/hooks/useCetesRate.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { parsearError } from "../utils/errores.js";
 
 /**
  * Fetches current CETES APY from Etherfuse sandbox.
@@ -7,6 +8,7 @@ import { useState, useEffect } from "react";
 export function useCetesRate() {
   const [rate, setRate]     = useState(null);   // number, e.g. 9.45
   const [loading, setLoading] = useState(true);
+  const [error, setError]   = useState(null);
 
   useEffect(() => {
     const apiKey = import.meta.env.VITE_ETHERFUSE_API_KEY;
@@ -27,9 +29,12 @@ export function useCetesRate() {
         const apy = cetes?.apy ?? cetes?.rate ?? cetes?.annual_yield ?? 9.45;
         setRate(Number(apy));
       })
-      .catch(() => setRate(9.45))
+      .catch(e => {
+        setError(parsearError(e));
+        setRate(9.45);
+      })
       .finally(() => setLoading(false));
   }, []);
 
-  return { rate, loading };
+  return { rate, loading, error };
 }

--- a/bimex-frontend/src/i18n/en.json
+++ b/bimex-frontend/src/i18n/en.json
@@ -5,7 +5,8 @@
     "testnet": "Testnet",
     "admin": "Admin",
     "logout": "Sign out",
-    "loggingOut": "..."
+    "loggingOut": "...",
+    "transparency": "Transparency"
   },
   "lang": {
     "toggle": "ES"
@@ -31,7 +32,9 @@
     "locked": "Locked",
     "goal": "Goal",
     "verified": "✓ Verified",
-    "verifiedTitle": "Documents verified on blockchain"
+    "verifiedTitle": "Documents verified on blockchain",
+    "loadMore": "Load more",
+    "remaining": "remaining"
   },
   "filters": {
     "all": "All",
@@ -191,7 +194,6 @@
     "goal": "Goal",
     "viewDetails": "View details →",
     "myContribution": "Your contribution",
-    "yieldAccum": "Accumulated yield",
     "viewDetailsShort": "View details",
     "withdraw": "Withdraw",
     "totalInvestedLabel": "Total invested",
@@ -227,6 +229,29 @@
     "toastApproved": "✅ Project #{{id}} approved",
     "toastRejected": "❌ Project #{{id}} rejected",
     "errLoad": "Could not load projects: {{msg}}"
+  },
+  "transp": {
+    "title": "Public Transparency",
+    "subtitle": "Real-time data from Stellar smart contract. No intermediaries.",
+    "back": "← Back",
+    "statTotal": "Projects",
+    "statLocked": "MXNe locked",
+    "statProgress": "In progress",
+    "statYield": "Yield generated",
+    "loading": "Loading blockchain data…",
+    "empty": "No public projects yet",
+    "emptyHint": "Projects will appear here when created.",
+    "noResults": "No projects in this state",
+    "viewAll": "View all",
+    "verified": "Verified",
+    "infoTitle": "On-chain data",
+    "infoDesc": "This information comes directly from the smart contract on Stellar Testnet. It cannot be manipulated.",
+    "retry": "Retry",
+    "errorLoad": "Could not load data. Check your connection.",
+    "filterLabel": "Filter by status:",
+    "funding": "Funding",
+    "goal": "Goal",
+    "locked": "Locked"
   },
   "recompensas": {
     "label": "Your rewards",

--- a/bimex-frontend/src/i18n/es.json
+++ b/bimex-frontend/src/i18n/es.json
@@ -5,7 +5,8 @@
     "testnet": "Testnet",
     "admin": "Admin",
     "logout": "Salir",
-    "loggingOut": "..."
+    "loggingOut": "...",
+    "transparency": "Transparencia"
   },
   "lang": {
     "toggle": "EN"
@@ -31,7 +32,9 @@
     "locked": "Bloqueado",
     "goal": "Meta",
     "verified": "✓ Verificado",
-    "verifiedTitle": "Documentos verificados en blockchain"
+    "verifiedTitle": "Documentos verificados en blockchain",
+    "loadMore": "Ver más",
+    "remaining": "restantes"
   },
   "filters": {
     "all": "Todos",
@@ -191,7 +194,6 @@
     "goal": "Meta",
     "viewDetails": "Ver detalles →",
     "myContribution": "Tu aportación",
-    "yieldAccum": "Yield acumulado",
     "viewDetailsShort": "Ver detalles",
     "withdraw": "Retirar",
     "totalInvestedLabel": "Total invertido",
@@ -227,6 +229,29 @@
     "toastApproved": "✅ Proyecto #{{id}} aprobado",
     "toastRejected": "❌ Proyecto #{{id}} rechazado",
     "errLoad": "No se pudieron cargar los proyectos: {{msg}}"
+  },
+  "transp": {
+    "title": "Transparencia pública",
+    "subtitle": "Datos en tiempo real del contrato inteligente en Stellar. Sin intermediarios.",
+    "back": "← Volver",
+    "statTotal": "Proyectos",
+    "statLocked": "MXNe bloqueado",
+    "statProgress": "En progreso",
+    "statYield": "Yield generado",
+    "loading": "Cargando datos del blockchain…",
+    "empty": "Sin proyectos públicos todavía",
+    "emptyHint": "Los proyectos aparecerán aquí cuando sean creados.",
+    "noResults": "Sin proyectos en este estado",
+    "viewAll": "Ver todos",
+    "verified": "Verificado",
+    "infoTitle": "Datos en cadena",
+    "infoDesc": "Esta información proviene directamente del contrato inteligente en Stellar Testnet. No puede ser manipulada.",
+    "retry": "Reintentar",
+    "errorLoad": "No se pudo cargar la información. Verifica tu conexión.",
+    "filterLabel": "Filtrar por estado:",
+    "funding": "Financiamiento",
+    "goal": "Meta",
+    "locked": "Bloqueado"
   },
   "recompensas": {
     "label": "Tus recompensas",

--- a/bimex-frontend/src/index.css
+++ b/bimex-frontend/src/index.css
@@ -842,6 +842,14 @@ label {
   .admin-meta-grid { flex-direction: column !important; gap: 10px !important; }
 }
 
+@media (max-width: 400px) {
+  .navbar-logo { font-size: 0.85rem !important; }
+  .navbar-actions { gap: 4px !important; }
+  .wallet-chip { padding: 4px 8px !important; font-size: 0.68rem !important; }
+  .navbar-btn-salir { padding: 3px 7px !important; font-size: 0.68rem !important; }
+  .navbar-btn-admin { padding: 3px 7px !important; font-size: 0.68rem !important; }
+}
+
 @media (max-width: 768px) {
   .landing-stats-bar { padding: 28px 20px; }
   .landing-stats-item { padding: 0 20px; }

--- a/bimex-frontend/src/stellar/contrato.js
+++ b/bimex-frontend/src/stellar/contrato.js
@@ -165,12 +165,9 @@ export async function obtenerBalanceMXNe(direccion) {
 
 export async function obtenerTotalProyectos() {
   try {
-    console.log("[Bimex] llamando total_proyectos en contrato:", CONFIG.CONTRACT_ID);
     const total = await simularLectura("total_proyectos", []);
-    console.log("[Bimex] total_proyectos respuesta:", total);
     return Number(total);
-  } catch (e) {
-    console.error("[Bimex] Error en total_proyectos:", e);
+  } catch {
     return 0;
   }
 }
@@ -191,6 +188,7 @@ function decodificarEstado(rawEstado) {
   if (nombre === "EnProgreso")  return "EnProgreso";
   if (nombre === "EnRevision")  return "EnRevision";
   if (nombre === "Rechazado")   return "Rechazado";
+  if (nombre === "EtapaInicial") return "EtapaInicial";
   return "EtapaInicial";
 }
 
@@ -435,7 +433,8 @@ export async function hashearDocumentos(ine, plan, presupuesto) {
 // ─── Helpers de formato ───────────────────────────────────────────────────────
 
 export function stroopsAMXNe(stroops) {
-  const valor = Number(BigInt(stroops)) / 10_000_000;
+  const b = typeof stroops === "bigint" ? stroops : BigInt(stroops ?? 0);
+  const valor = Number(b / BigInt(10_000_000)) + Number(b % BigInt(10_000_000)) / 10_000_000;
   return `${valor.toLocaleString("es-MX", { minimumFractionDigits: 2 })} MXNe`;
 }
 

--- a/bimex-frontend/src/test/contrato.test.js
+++ b/bimex-frontend/src/test/contrato.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@stellar/stellar-sdk', () => ({
+  Contract: vi.fn(),
+  Networks: { TESTNET: 'Test SDF Network ; September 2015', PUBLIC: 'Public Global Stellar Network ; September 2015' },
+  rpc: {
+    Server: vi.fn(),
+    Api: {
+      isSimulationError: vi.fn(() => false),
+      isSimulationRestore: vi.fn(() => false),
+      GetTransactionStatus: { SUCCESS: 'SUCCESS', FAILED: 'FAILED' },
+    },
+  },
+  TransactionBuilder: vi.fn(),
+  BASE_FEE: '100',
+  Address: vi.fn(),
+  Keypair: { random: vi.fn(() => ({ publicKey: () => 'GABC123' })), fromSecret: vi.fn() },
+  nativeToScVal: vi.fn(),
+  scValToNative: vi.fn(),
+}));
+
+vi.mock('@stellar/freighter-api', () => ({
+  signTransaction: vi.fn(),
+  isConnected: vi.fn(),
+  isAllowed: vi.fn(),
+  requestAccess: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  setAllowed: vi.fn(),
+}));
+
+import { stroopsAMXNe, mxneAStroops } from '../stellar/contrato.js';
+
+describe('stroopsAMXNe', () => {
+  it('converts 10_000_000 stroops to a string containing "1" and "MXNe"', () => {
+    const result = stroopsAMXNe(BigInt(10_000_000));
+    expect(result).toContain('1');
+    expect(result).toContain('MXNe');
+  });
+
+  it('converts 0 stroops to a string containing "0" and "MXNe"', () => {
+    const result = stroopsAMXNe(BigInt(0));
+    expect(result).toContain('0');
+    expect(result).toContain('MXNe');
+  });
+
+  it('converts 15_000_000 stroops to a string containing "1.5" or "1,5" and "MXNe"', () => {
+    const result = stroopsAMXNe(BigInt(15_000_000));
+    expect(result).toMatch(/1[.,]5[0-9]*\s+MXNe/);
+  });
+
+  it('returns a string type', () => {
+    expect(typeof stroopsAMXNe(BigInt(10_000_000))).toBe('string');
+  });
+
+  it('converts 100_000_000 stroops to contain "10" and "MXNe"', () => {
+    const result = stroopsAMXNe(BigInt(100_000_000));
+    expect(result).toContain('10');
+    expect(result).toContain('MXNe');
+  });
+});
+
+describe('mxneAStroops', () => {
+  it('converts 1 MXNe to 10_000_000 stroops as BigInt', () => {
+    expect(mxneAStroops(1)).toBe(BigInt(10_000_000));
+  });
+
+  it('converts 0 MXNe to 0 stroops as BigInt', () => {
+    expect(mxneAStroops(0)).toBe(BigInt(0));
+  });
+
+  it('converts 1.5 MXNe to 15_000_000 stroops as BigInt', () => {
+    expect(mxneAStroops(1.5)).toBe(BigInt(15_000_000));
+  });
+
+  it('converts 100 MXNe to 1_000_000_000 stroops as BigInt', () => {
+    expect(mxneAStroops(100)).toBe(BigInt(1_000_000_000));
+  });
+
+  it('returns a BigInt type', () => {
+    expect(typeof mxneAStroops(1)).toBe('bigint');
+  });
+});

--- a/bimex-frontend/src/test/errores.test.js
+++ b/bimex-frontend/src/test/errores.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parsearError, esErrorDeConexion } from '../utils/errores.js';
+
+describe('parsearError', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns "Sin conexión" for ERR_INTERNET_DISCONNECTED', () => {
+    const result = parsearError(new Error('net::ERR_INTERNET_DISCONNECTED'));
+    expect(result).toContain('Sin conexión');
+  });
+
+  it('returns "Sin conexión" when navigator.onLine is false', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, writable: true, configurable: true });
+    const result = parsearError(new Error('some error'));
+    expect(result).toContain('Sin conexión');
+  });
+
+  it('returns message containing "Freighter" for Freighter not installed error', () => {
+    const result = parsearError(new Error('Freighter is not installed'));
+    expect(result).toContain('Freighter');
+  });
+
+  it('returns message containing "Cancelaste" for User declined', () => {
+    const result = parsearError(new Error('User declined'));
+    expect(result).toContain('Cancelaste');
+  });
+
+  it('returns message containing "solicitudes" for rate limit 429', () => {
+    const result = parsearError(new Error('429 Too Many Requests'));
+    expect(result).toContain('solicitudes');
+  });
+
+  it('returns message about timeout for ETIMEDOUT', () => {
+    const result = parsearError(new Error('ETIMEDOUT'));
+    expect(result.toLowerCase()).toMatch(/tard|tiempo/);
+  });
+
+  it('returns message about insufficient funds for "insufficient balance"', () => {
+    const result = parsearError(new Error('insufficient balance'));
+    expect(result).toMatch(/Saldo insuficiente|Fondos/);
+  });
+
+  it('returns message about meta for HostError with meta validation', () => {
+    const result = parsearError(new Error('HostError: La meta debe ser mayor'));
+    expect(result.toLowerCase()).toContain('meta');
+  });
+
+  it('returns message about authorization for HostError require_auth', () => {
+    const result = parsearError(new Error('HostError: require_auth failed'));
+    expect(result).toContain('autorización');
+  });
+
+  it('returns message about IPFS for IPFS upload error', () => {
+    const result = parsearError(new Error('IPFS upload failed'));
+    expect(result).toContain('IPFS');
+  });
+
+  it('returns message about trustline for missing trustline', () => {
+    const result = parsearError(new Error('trustline not found'));
+    expect(result).toContain('trustline');
+  });
+
+  it('returns original message for unknown short error', () => {
+    const result = parsearError(new Error('something small'));
+    expect(result).toBe('something small');
+  });
+
+  it('truncates long unknown error messages with ellipsis', () => {
+    const longMessage = 'x'.repeat(200);
+    const result = parsearError(new Error(longMessage));
+    expect(result.length).toBeLessThanOrEqual(144);
+    expect(result).toContain('…');
+  });
+
+  it('does not throw and returns a string for null input', () => {
+    expect(() => parsearError(null)).not.toThrow();
+    expect(typeof parsearError(null)).toBe('string');
+  });
+
+  it('does not throw and returns a string for undefined input', () => {
+    expect(() => parsearError(undefined)).not.toThrow();
+    expect(typeof parsearError(undefined)).toBe('string');
+  });
+});
+
+describe('esErrorDeConexion', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true });
+  });
+
+  it('returns true for ERR_CONNECTION_REFUSED', () => {
+    expect(esErrorDeConexion(new Error('net::ERR_CONNECTION_REFUSED'))).toBe(true);
+  });
+
+  it('returns true for Failed to fetch', () => {
+    expect(esErrorDeConexion(new Error('Failed to fetch'))).toBe(true);
+  });
+
+  it('returns true for ETIMEDOUT', () => {
+    expect(esErrorDeConexion(new Error('ETIMEDOUT'))).toBe(true);
+  });
+
+  it('returns false for User declined', () => {
+    expect(esErrorDeConexion(new Error('User declined'))).toBe(false);
+  });
+
+  it('returns false for HostError require_auth', () => {
+    expect(esErrorDeConexion(new Error('HostError: require_auth'))).toBe(false);
+  });
+});

--- a/bimex-frontend/src/test/setup.js
+++ b/bimex-frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/bimex-frontend/src/utils/errores.js
+++ b/bimex-frontend/src/utils/errores.js
@@ -5,7 +5,67 @@
 export function parsearError(err) {
   const raw = err?.message || String(err) || "Error desconocido";
 
-  // ── Errores de contrato (Soroban / WasmVm) ────────────────────────────────
+  // ── Conectividad / sin internet ───────────────────────────────────────────────
+  if (!navigator.onLine || raw.includes("ERR_INTERNET_DISCONNECTED") || raw.includes("net::ERR"))
+    return "Sin conexión a internet. Revisa tu red e intenta de nuevo.";
+  if (raw.includes("ERR_NAME_NOT_RESOLVED") || raw.includes("DNS"))
+    return "No se pudo resolver el servidor. Verifica tu conexión.";
+  if (raw.includes("ECONNREFUSED"))
+    return "Conexión rechazada por el servidor. El servicio puede estar caído.";
+
+  // ── RPC / Soroban node ────────────────────────────────────────────────────────
+  if (raw.includes("502") || raw.includes("503") || raw.includes("Bad Gateway"))
+    return "El nodo RPC de Soroban está temporalmente no disponible. Intenta en unos minutos.";
+  if (raw.includes("429") || raw.includes("Too Many Requests") || raw.includes("rate limit"))
+    return "Demasiadas solicitudes. Espera unos segundos e intenta de nuevo.";
+  if (raw.includes("timeout") || raw.includes("Timeout") || raw.includes("ETIMEDOUT"))
+    return "La solicitud tardó demasiado. Verifica tu conexión y vuelve a intentar.";
+  if (raw.includes("socket hang up") || raw.includes("ECONNRESET"))
+    return "La conexión se interrumpió. Intenta de nuevo.";
+
+  // ── Freighter wallet (específico) ─────────────────────────────────────────────
+  if (raw.includes("Freighter is not installed") || (raw.includes("freighter") && raw.includes("undefined")))
+    return "Freighter no está instalado. Instálalo desde la Chrome Web Store para continuar.";
+  if (raw.includes("locked") || raw.includes("Wallet is locked"))
+    return "Freighter está bloqueado. Desbloquéalo con tu contraseña e intenta de nuevo.";
+  if (raw.includes("not allowed") || raw.includes("Not allowed"))
+    return "Freighter no tiene permiso para conectar con esta app. Abre Freighter y acepta la conexión.";
+  if (raw.includes("wrong network") || raw.includes("red incorrecta"))
+    return "Tu Freighter está en una red diferente. Cámbialo a Testnet (o Mainnet según corresponda).";
+
+  // ── IPFS / Pinata ─────────────────────────────────────────────────────────────
+  if (raw.includes("pinata") || raw.includes("IPFS") || raw.includes("ipfs"))
+    return "Error al subir documentos a IPFS. Los documentos se guardarán con hash local como respaldo.";
+  if (raw.includes("413") || raw.includes("Payload Too Large"))
+    return "El archivo es demasiado grande. El límite es 10 MB por documento.";
+
+  // ── Token / MXNe ──────────────────────────────────────────────────────────────
+  if (raw.includes("not authorized") && raw.includes("token"))
+    return "No tienes autorización para transferir este token. Asegúrate de tener MXNe en tu wallet.";
+  if (raw.includes("trustline"))
+    return "Tu wallet no tiene una trustline para MXNe. Necesitas agregarla desde Freighter.";
+  if (raw.includes("token_transfer") || raw.includes("ClassicOp"))
+    return "Error al transferir MXNe. Revisa que tengas saldo suficiente y la trustline activa.";
+
+  // ── Estado / lógica de contrato ───────────────────────────────────────────────
+  if (raw.includes("Proyecto no encontrado") || raw.includes("project not found"))
+    return "Proyecto no encontrado. Puede haber sido eliminado o el ID es incorrecto.";
+  if (raw.includes("Estado incorrecto") || raw.includes("invalid state") || raw.includes("InvalidState"))
+    return "Esta acción no está permitida en el estado actual del proyecto.";
+  if (raw.includes("Aportacion no encontrada") || raw.includes("contribution not found"))
+    return "No tienes una aportación registrada en este proyecto.";
+  if (raw.includes("Fecha de inicio") || raw.includes("start_date"))
+    return "La fecha de inicio del proyecto no es válida.";
+  if (raw.includes("Plazo invalido") || raw.includes("invalid duration"))
+    return "El plazo del proyecto no es válido. Debe ser entre 1 y 60 meses.";
+
+  // ── Sesión / autenticación ────────────────────────────────────────────────────
+  if (raw.includes("session expired") || raw.includes("sesión expirada"))
+    return "Tu sesión ha expirado. Reconecta tu wallet para continuar.";
+  if (raw.includes("signature") || raw.includes("Signature"))
+    return "Error de firma digital. Intenta firmar la transacción de nuevo en Freighter.";
+
+  // ── Errores de contrato (Soroban / WasmVm) ────────────────────────────────────
   if (raw.includes("HostError") || raw.includes("WasmVm") || raw.includes("UnreachableCode") || raw.includes("InvalidAction")) {
     if (raw.includes("La meta debe ser mayor"))      return "La meta del proyecto debe ser mayor a 0 MXNe.";
     if (raw.includes("alcanzo su meta"))             return "Este proyecto ya alcanzó su meta de financiamiento.";
@@ -17,11 +77,10 @@ export function parsearError(err) {
     if (raw.includes("Solo el admin"))               return "Solo el administrador puede realizar esta acción.";
     if (raw.includes("require_auth") || raw.includes("Auth"))
                                                      return "Error de autorización. Verifica que tu wallet esté conectada correctamente.";
-    // Error genérico de contrato (raro)
     return "Error en el contrato inteligente. El contrato en testnet puede necesitar ser redesPlegado. Contacta al administrador.";
   }
 
-  // ── Errores de Freighter / wallet ─────────────────────────────────────────
+  // ── Errores de Freighter / wallet ─────────────────────────────────────────────
   if (raw.includes("rechazó la firma") || raw.includes("User declined"))
     return "Cancelaste la transacción en Freighter.";
   if (raw.includes("no devolvió una transacción firmada"))
@@ -29,7 +88,7 @@ export function parsearError(err) {
   if (raw.includes("Freighter"))
     return "Error con Freighter Wallet. Asegúrate de que esté desbloqueado y en Testnet.";
 
-  // ── Errores de red / RPC ──────────────────────────────────────────────────
+  // ── Errores de red / RPC ──────────────────────────────────────────────────────
   if (raw.includes("Tiempo de espera agotado"))
     return "La transacción tardó demasiado. Puede haber confirmado igual — verifica en el explorador de Stellar.";
   if (raw.includes("falló en la red") || raw.includes("XDR"))
@@ -41,12 +100,42 @@ export function parsearError(err) {
   if (raw.includes("no devolvió valor"))
     return "El contrato no respondió. El RPC puede estar caído — intenta en unos minutos.";
 
-  // ── Errores de saldo / fondos ─────────────────────────────────────────────
+  // ── Errores de saldo / fondos ─────────────────────────────────────────────────
   if (raw.includes("insufficient") || raw.includes("balance") || raw.includes("saldo"))
     return "Saldo insuficiente. Obtén MXNe de prueba con el botón '100 MXNe'.";
   if (raw.includes("op_underfunded"))
     return "Fondos insuficientes en tu wallet para cubrir la transacción.";
 
-  // ── Mensaje genérico (truncado si es muy largo) ───────────────────────────
+  // ── Mensaje genérico (truncado si es muy largo) ───────────────────────────────
   return raw.length > 140 ? raw.slice(0, 140) + "…" : raw;
+}
+
+/**
+ * Devuelve true si el error es probablemente de red/conectividad
+ * (sin internet, timeout, RPC caído) — útil para mostrar botón de reintentar.
+ */
+export function esErrorDeConexion(err) {
+  const raw = err?.message || String(err) || "";
+  if (!navigator.onLine) return true;
+  return (
+    raw.includes("ERR_INTERNET_DISCONNECTED") ||
+    raw.includes("net::ERR") ||
+    raw.includes("ERR_NAME_NOT_RESOLVED") ||
+    raw.includes("DNS") ||
+    raw.includes("ECONNREFUSED") ||
+    raw.includes("502") ||
+    raw.includes("503") ||
+    raw.includes("Bad Gateway") ||
+    raw.includes("429") ||
+    raw.includes("Too Many Requests") ||
+    raw.includes("rate limit") ||
+    raw.includes("timeout") ||
+    raw.includes("Timeout") ||
+    raw.includes("ETIMEDOUT") ||
+    raw.includes("socket hang up") ||
+    raw.includes("ECONNRESET") ||
+    raw.includes("NetworkError") ||
+    raw.includes("Failed to fetch") ||
+    raw.includes("no devolvió valor")
+  );
 }

--- a/bimex-frontend/vite.config.js
+++ b/bimex-frontend/vite.config.js
@@ -11,4 +11,9 @@ export default defineConfig({
       buffer: 'buffer',
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.js',
+  },
 })


### PR DESCRIPTION
## Resumen

- **BigInt safety**: type guard + `try/catch` en todos los `reduce` que suman BigInt (App, ListaProyectos, MiCuenta, Recompensas, Transparencia); división BigInt-first en `stroopsAMXNe` para evitar pérdida de precisión
- **Errores personalizados**: 7 categorías nuevas en `errores.js` (offline, RPC/Soroban, Freighter, IPFS, token MXNe, estado contrato, sesión) + export `esErrorDeConexion`
- **DetalleProyecto**: `balanceMXNe` arranca en `null`; balance y validación de monto solo activos cuando carga correctamente; botón "Reclamar rendimiento" solo visible cuando `estado === "Liberado"`
- **CrearProyecto**: focus trap completo (Tab cíclico, Escape, restauración de foco); validación de tamaño de archivo con error visible; `tiempoMeses` clamp [1, 120]
- **AdminPanel**: captura `motivo` antes del async; guard motivo vacío antes de rechazar
- **App**: `manejarConectado` en `useCallback`; logout con timeout 4 s anti-freeze Freighter; cache `liveStats` 15 s; routing transparencia pública sin wallet guard
- **ConectarWallet**: guard longitud dirección post-`getAddress`; guard `networkPassphrase` undefined
- **ListaProyectos**: mutex `cargandoRef` anti-concurrencia; paginación 12 + "Ver más"; `aria-pressed` en filtros
- **MiCuenta**: `onTotalInvertido` en deps; `.catch` en query Supabase de `NotificacionesPanel`
- **Recompensas**: flag `cancelado` + BigInt precision en ambos paths
- **Transparencia**: página pública nueva sin wallet; filtros; stats on-chain; yield con collect+reduce seguro
- **i18n**: claves `transp.*`, `nav.transparency`, `lista.loadMore`, `lista.remaining`; eliminada clave huérfana `cuenta.yieldAccum`
- **Tests**: Vitest + jsdom configurado; 30 tests (errores + contrato); regex ajustado
- **CSS**: fix navbar iPhone SE (`max-width: 400px`)

## Plan de prueba

- [ ] `npm run test:run` → 30 tests, 0 failures
- [ ] Abrir app con balance cargado → hint "Disponible: X MXNe" aparece; con balance fallido no aparece
- [ ] Proyecto en EtapaInicial/EnProgreso como dueño → botón "Reclamar rendimiento" no aparece
- [ ] Proyecto Liberado como dueño → botón aparece
- [ ] Abrir CrearProyecto con Tab → foco queda atrapado dentro del modal; Escape lo cierra
- [ ] Viewport 375px → navbar se ve correctamente en iPhone SE

🤖 Generated with [Claude Code](https://claude.com/claude-code)