### PR TITLE
feat: SSE real-time updates + public changelog (#62, #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to Bimex are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [Unreleased]
+
+### Added
+- SSE real-time updates: indexer pushes `proyecto_actualizado`, `nueva_contribucion`, `yield_reclamado` events to connected clients (#62)
+- Public changelog page accessible from the app footer (#81)
+
+---
+
+## [2.1.0] — 2026-05-27
+
+### Added
+- Dark mode with toggle in navbar (#59)
+- Project search with debounce (#60)
+- Share project with QR code (#61)
+- Transparency page with on-chain stats (#57)
+- Rewards panel (`Recompensas.jsx`) connected to real contract data (#56)
+- CETES live rate via Etherfuse displayed in landing stats bar (#55)
+- i18n support (Spanish / English) with `react-i18next` (#53)
+- Skeleton loading states across all data-fetching components (#48)
+- Toast notification system replacing inline error messages (#50)
+
+### Improved
+- Code splitting: bundle reduced ~40% (#47)
+- Mobile-first responsive design across all views (#49)
+- Admin panel with project approval / rejection flow (#46)
+
+### Fixed
+- TTL management in contract storage (#64)
+- Security headers in Vercel deployment (#65)
+
+---
+
+## [2.0.0] — 2026-04-23
+
+### Added
+- `EnRevision` state: projects require admin approval before accepting funds
+- `admin_aprobar()` and `admin_rechazar()` contract functions
+- `Rechazado` state with `motivo_rechazo` field
+- `doc_hash` (BytesN<32>): SHA-256 document hash stored on-chain for verifiability
+- `calcular_yield_detallado()`: returns yield broken down by CETES and AMM
+- `estado_capital()`: returns current capital distribution
+- `solicitar_continuar()`: allows a new owner to resume an abandoned project
+- `bimex-indexer`: on-chain indexing service to extend persistent storage TTL and maintain event history
+
+### Fixed (security audit)
+- CEI pattern (Checks-Effects-Interactions) applied in `contribuir()`, `retirar_principal()`, `reclamar_yield()`, and `abandonar_proyecto()` — prevents reentrancy attacks
+- `require_auth()` moved to the start of every function that requires it, before any storage reads or business logic
+- Contribution cap: `cantidad = cantidad.min(restante)` prevents accidental or malicious overfunding
+- Top-up preserves the backer's original timestamp (additional contributions no longer reset the yield clock)
+- `solicitar_continuar()` resets `timestamp_inicio` so the new owner does not inherit accumulated yield from the previous period
+- `calcular_yield_seguro()` uses early division to avoid i128 overflow with large capitals
+- Bounds check in `inicializar()`: `yield_cetes_bps` and `yield_amm_bps` cannot exceed 10,000,000 bps
+
+### Changed
+- Yield rates updated to production values: CETES 9.45% APY (`yield_cetes_bps = 945`), AMM 4.00% APY (`yield_amm_bps = 400`)
+
+---
+
+## [1.0.0] — 2026-03-15
+
+### Added
+- Initial demo presented at Hack+ Alebrije (Stellar | CDMX)
+- Core contract functions: `crear_proyecto`, `contribuir`, `retirar_principal`, `reclamar_yield`
+- Basic React frontend with Freighter wallet integration
+- Stellar Testnet deployment

--- a/bimex-frontend/.env.example
+++ b/bimex-frontend/.env.example
@@ -5,6 +5,9 @@ VITE_TOKEN_MXNE=
 VITE_ADMIN_ADDRESS=
 VITE_FAUCET_SECRET=
 
+# Indexer API (for SSE real-time updates)
+VITE_INDEXER_URL=http://localhost:3001
+
 # Supabase (for notification preferences)
 VITE_SUPABASE_URL=https://<project>.supabase.co
 VITE_SUPABASE_ANON_KEY=<anon_key>

--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -9,6 +9,7 @@ import MiCuenta         from "./components/MiCuenta";
 import AdminPanel       from "./components/AdminPanel";
 import Recompensas      from "./components/Recompensas";
 import Transparencia    from "./components/Transparencia";
+import Changelog        from "./components/Changelog";
 import { getStorage }   from "./utils/storage";
 import { parsearError } from "./utils/errores";
 import { obtenerTodosLosProyectos, stroopsAMXNe, mintearMXNePrueba } from "./stellar/contrato";
@@ -213,6 +214,7 @@ export default function App() {
   const [modalCrear,     setModalCrear]     = useState(false);
   const [vistaActual,    setVistaActual]    = useState("proyectos");
   const [mostrandoTransparencia, setMostrandoTransparencia] = useState(false);
+  const [mostrandoChangelog,     setMostrandoChangelog]     = useState(false);
   const [adminPanel,     setAdminPanel]     = useState(false);
   const [autoConectar,   setAutoConectar]   = useState(leerAutoConectarInicial);
   const [cerrandoSesion, setCerrandoSesion] = useState(false);
@@ -279,8 +281,20 @@ export default function App() {
   if (mostrandoTransparencia) {
     return <Transparencia onVolver={() => setMostrandoTransparencia(false)} />;
   }
+  if (mostrandoChangelog) {
+    return (
+      <div>
+        <div style={{ padding: "16px 24px", borderBottom: "1px solid var(--border)" }}>
+          <button className="btn btn-ghost" onClick={() => setMostrandoChangelog(false)} style={{ fontSize: "0.84rem" }}>
+            ← Volver
+          </button>
+        </div>
+        <Changelog />
+      </div>
+    );
+  }
   if (!direccion) {
-    return <Landing autoConectar={autoConectar} onConectado={manejarConectado} onTransparencia={() => setMostrandoTransparencia(true)} />;
+    return <Landing autoConectar={autoConectar} onConectado={manejarConectado} onTransparencia={() => setMostrandoTransparencia(true)} onChangelog={() => setMostrandoChangelog(true)} />;
   }
 
   return (
@@ -383,6 +397,9 @@ export default function App() {
             {vistaActual === "transparencia" && (
               <Transparencia />
             )}
+            {vistaActual === "changelog" && (
+              <Changelog />
+            )}
             {vistaActual === "micuenta" && (
               <MiCuenta
                 direccion={direccion}
@@ -410,12 +427,22 @@ export default function App() {
           </>
         )}
       </main>
+      <footer style={{ ...st.footer, padding: "16px 40px" }}>
+        <button
+          onClick={() => { setProyectoActivo(null); setVistaActual("changelog"); }}
+          style={{ background: "none", border: "none", cursor: "pointer", color: "rgba(255,255,255,0.55)", fontSize: "0.78rem", fontWeight: 500, padding: "4px 8px" }}
+        >
+          Novedades
+        </button>
+        <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
+        <span style={{ color: "rgba(255,255,255,0.3)", fontSize: "0.78rem" }}>Bimex · Stellar Testnet</span>
+      </footer>
     </div>
   );
 }
 
 // ── Landing ──────────────────────────────────────────────────────────────────
-function Landing({ autoConectar, onConectado, onTransparencia }) {
+function Landing({ autoConectar, onConectado, onTransparencia, onChangelog }) {
   const liveStats = useLiveStats();
   const { rate: cetesRate, error: cetesError } = useCetesRate();
 
@@ -604,9 +631,12 @@ function Landing({ autoConectar, onConectado, onTransparencia }) {
           <LogoSVG size={20} light />
           <span style={{ fontWeight: 700, fontSize: "1rem", color: "rgba(255,255,255,0.85)" }}>Bimex</span>
         </div>
-        <p style={{ color: "rgba(255,255,255,0.35)", fontSize: "0.78rem" }}>
+        <p style={{ color: "rgba(255,255,255,0.35)", fontSize: "0.78rem", marginBottom: 10 }}>
           Hack+ Alebrije · Stellar · CDMX 2025 · Construido con Soroban y MXNe
         </p>
+        <button onClick={onChangelog} style={{ background: "none", border: "none", cursor: "pointer", color: "rgba(255,255,255,0.45)", fontSize: "0.78rem", fontWeight: 500, padding: 0 }}>
+          Novedades
+        </button>
       </footer>
     </div>
   );

--- a/bimex-frontend/src/components/Changelog.jsx
+++ b/bimex-frontend/src/components/Changelog.jsx
@@ -1,0 +1,136 @@
+const RELEASES = [
+  {
+    version: "Próximamente",
+    date: null,
+    sections: {
+      "Agregado": [
+        "Actualizaciones en tiempo real vía SSE: el indexer notifica cambios al instante (#62)",
+        "Esta página de changelog (#81)",
+      ],
+    },
+  },
+  {
+    version: "2.1.0",
+    date: "2026-05-27",
+    sections: {
+      "Agregado": [
+        "Dark mode con toggle en navbar (#59)",
+        "Búsqueda de proyectos con debounce (#60)",
+        "Compartir proyecto con código QR (#61)",
+        "Página de transparencia con estadísticas on-chain (#57)",
+        "Panel de recompensas conectado a datos reales del contrato (#56)",
+        "Tasa CETES en vivo vía Etherfuse en la landing (#55)",
+        "Soporte i18n español / inglés (#53)",
+        "Skeleton loading states en todos los componentes (#48)",
+        "Sistema de toasts reemplazando errores inline (#50)",
+      ],
+      "Mejorado": [
+        "Code splitting: bundle reducido ~40% (#47)",
+        "Diseño responsive mobile-first (#49)",
+        "Panel admin con flujo de aprobación y rechazo (#46)",
+      ],
+      "Corregido": [
+        "TTL management en storage del contrato (#64)",
+        "Security headers en despliegue Vercel (#65)",
+      ],
+    },
+  },
+  {
+    version: "2.0.0",
+    date: "2026-04-23",
+    sections: {
+      "Agregado": [
+        "Estado EnRevision: proyectos requieren aprobación del admin antes de aceptar fondos",
+        "Funciones admin_aprobar() y admin_rechazar() en el contrato",
+        "Estado Rechazado con campo motivo_rechazo",
+        "doc_hash (BytesN<32>): hash SHA-256 del documento almacenado on-chain",
+        "calcular_yield_detallado(): yield desglosado por CETES y AMM",
+        "estado_capital(): distribución actual del capital",
+        "solicitar_continuar(): permite a un nuevo dueño retomar un proyecto abandonado",
+        "bimex-indexer: servicio de indexación on-chain",
+      ],
+      "Corregido (auditoría de seguridad)": [
+        "Patrón CEI aplicado en contribuir(), retirar_principal(), reclamar_yield() y abandonar_proyecto()",
+        "require_auth() movido al inicio de cada función antes de cualquier lectura de storage",
+        "Cap de contribución: cantidad = cantidad.min(restante) previene overfunding",
+        "Top-up preserva el timestamp original del backer",
+        "calcular_yield_seguro() usa división anticipada para evitar overflow en i128",
+        "Bounds check en inicializar(): yield_cetes_bps y yield_amm_bps no pueden exceder 10,000,000 bps",
+      ],
+      "Cambiado": [
+        "Tasas actualizadas a producción: CETES 9.45% APY, AMM 4.00% APY",
+      ],
+    },
+  },
+  {
+    version: "1.0.0",
+    date: "2026-03-15",
+    sections: {
+      "Agregado": [
+        "Demo inicial presentada en Hack+ Alebrije (Stellar | CDMX)",
+        "Funciones base del contrato: crear_proyecto, contribuir, retirar_principal, reclamar_yield",
+        "Frontend React con integración Freighter",
+        "Despliegue en Stellar Testnet",
+      ],
+    },
+  },
+];
+
+const SECTION_COLOR = {
+  "Agregado": "var(--green)",
+  "Mejorado": "var(--navy)",
+  "Corregido": "var(--amber)",
+  "Corregido (auditoría de seguridad)": "var(--amber)",
+  "Cambiado": "var(--muted)",
+  "Próximamente": "var(--navy)",
+};
+
+export default function Changelog() {
+  return (
+    <div style={{ maxWidth: 760, margin: "0 auto", padding: "40px 24px" }}>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 700, color: "var(--text)", marginBottom: 6 }}>
+        Novedades
+      </h1>
+      <p style={{ color: "var(--muted)", fontSize: "0.88rem", marginBottom: 36 }}>
+        Historial de cambios de Bimex. Formato{" "}
+        <a href="https://keepachangelog.com/es/1.0.0/" target="_blank" rel="noreferrer" style={{ color: "var(--navy)" }}>
+          Keep a Changelog
+        </a>.
+      </p>
+
+      {RELEASES.map((release) => (
+        <section key={release.version} style={{ marginBottom: 40 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 16, borderBottom: "1px solid var(--border)", paddingBottom: 10 }}>
+            <h2 style={{ fontSize: "1.05rem", fontWeight: 700, color: "var(--text)", margin: 0 }}>
+              {release.version === "Próximamente" ? (
+                <span style={{ background: "var(--navy-dim)", color: "var(--navy)", padding: "2px 10px", borderRadius: 99, fontSize: "0.82rem", fontWeight: 600 }}>
+                  Próximamente
+                </span>
+              ) : (
+                `v${release.version}`
+              )}
+            </h2>
+            {release.date && (
+              <span style={{ fontSize: "0.8rem", color: "var(--muted)" }}>{release.date}</span>
+            )}
+          </div>
+
+          {Object.entries(release.sections).map(([section, items]) => (
+            <div key={section} style={{ marginBottom: 16 }}>
+              <h3 style={{ fontSize: "0.75rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.07em", color: SECTION_COLOR[section] ?? "var(--muted)", marginBottom: 8 }}>
+                {section}
+              </h3>
+              <ul style={{ margin: 0, paddingLeft: 20, display: "flex", flexDirection: "column", gap: 5 }}>
+                {items.map((item) => (
+                  <li key={item} style={{ fontSize: "0.88rem", color: "var(--text2)", lineHeight: 1.6 }}>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/bimex-frontend/src/components/ListaProyectos.jsx
+++ b/bimex-frontend/src/components/ListaProyectos.jsx
@@ -40,6 +40,18 @@ export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
   useEffect(() => { cargar(); }, [refrescar]);
   useEffect(() => { setVisibles(12); }, [filtro]);
 
+  useEffect(() => {
+    const url = import.meta.env.VITE_INDEXER_URL;
+    if (!url) return;
+    const es = new EventSource(`${url}/sse`);
+    const recargar = () => cargar();
+    es.addEventListener('proyecto_actualizado', recargar);
+    es.addEventListener('nueva_contribucion', recargar);
+    es.addEventListener('yield_reclamado', recargar);
+    es.onerror = () => es.close();
+    return () => es.close();
+  }, []);
+
   const proyectosPublicos = proyectos.filter(p => !ESTADOS_OCULTOS.has(p.estado));
   const totalBloqueado = proyectosPublicos.reduce((s, p) => {
     try { return s + BigInt(p.aportado ?? 0); } catch { return s; }

--- a/bimex-indexer/.env.example
+++ b/bimex-indexer/.env.example
@@ -8,3 +8,5 @@ START_LEDGER=0
 POLL_INTERVAL_MS=10000
 # Analytics API port
 API_PORT=3001
+# Allowed origin for SSE CORS (set to your frontend URL in production)
+FRONTEND_URL=http://localhost:5173

--- a/bimex-indexer/api.js
+++ b/bimex-indexer/api.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import http from 'node:http';
 import supabase from './database.js';
+import { agregarCliente, eliminarCliente } from './sse.js';
 
 const PORT = parseInt(process.env.API_PORT ?? '3001', 10);
 
@@ -73,6 +74,20 @@ async function route(req, res) {
                            .reduce((s, a) => s + Number(a.monto ?? 0), 0),
     };
     return json(res, 200, stats);
+  }
+
+  // GET /sse — Server-Sent Events stream
+  if (parts[0] === 'sse' && !parts[1]) {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'Access-Control-Allow-Origin': process.env.FRONTEND_URL || '*',
+    });
+    res.write(':ok\n\n');
+    agregarCliente(res);
+    req.on('close', () => eliminarCliente(res));
+    return;
   }
 
   json(res, 404, { error: 'Not found' });

--- a/bimex-indexer/index.js
+++ b/bimex-indexer/index.js
@@ -2,6 +2,8 @@ import 'dotenv/config';
 import { SorobanRpc } from '@stellar/stellar-sdk';
 import { parseTx } from './eventParser.js';
 import { upsertProyecto, upsertAportacion, insertEvento, getLastIndexedLedger } from './database.js';
+import { notificarClientes } from './sse.js';
+import './api.js'; // start HTTP + SSE server in the same process
 
 const RPC_URL         = process.env.STELLAR_RPC_URL;
 const CONTRACT_ID     = process.env.CONTRACT_ID;
@@ -31,8 +33,9 @@ async function processBatch(startLedger) {
 
     const { evento, proyecto, aportacion } = parsed;
     await insertEvento(evento).catch(console.error);
-    if (proyecto)   await upsertProyecto(proyecto).catch(console.error);
-    if (aportacion) await upsertAportacion(aportacion).catch(console.error);
+    if (proyecto)   { await upsertProyecto(proyecto).catch(console.error); notificarClientes('proyecto_actualizado', { id: proyecto.id, estado: proyecto.estado }); }
+    if (aportacion) { await upsertAportacion(aportacion).catch(console.error); notificarClientes('nueva_contribucion', { proyectoId: aportacion.proyecto_id, monto: aportacion.monto }); }
+    if (evento.tipo === 'yield_reclamado') notificarClientes('yield_reclamado', { proyectoId: evento.proyecto_id, monto: evento.monto });
 
     console.log(`[${new Date().toISOString()}] ${evento.tipo} ledger=${evento.ledger} tx=${evento.tx_hash}`);
   }

--- a/bimex-indexer/sse.js
+++ b/bimex-indexer/sse.js
@@ -1,0 +1,17 @@
+// Shared SSE client registry — imported by both api.js and index.js
+const clientes = new Set();
+
+export function agregarCliente(res) {
+  clientes.add(res);
+}
+
+export function eliminarCliente(res) {
+  clientes.delete(res);
+}
+
+export function notificarClientes(tipo, datos) {
+  const msg = `event: ${tipo}\ndata: ${JSON.stringify(datos)}\n\n`;
+  for (const cliente of clientes) {
+    try { cliente.write(msg); } catch { clientes.delete(cliente); }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #62 — replaces manual refresh with Server-Sent Events for real-time updates.
Closes #81 — adds a public changelog page accessible from the app footer.

## #62 — SSE real-time updates

**How it works:** `index.js` and `api.js` now run in the same process (index imports api), sharing a single `sse.js` module that holds the connected-client Set.

| File | Change |
|---|---|
| `bimex-indexer/sse.js` | New — `agregarCliente`, `eliminarCliente`, `notificarClientes` |
| `bimex-indexer/api.js` | New `GET /sse` endpoint; SSE headers + client cleanup on close |
| `bimex-indexer/index.js` | Imports `api.js` + calls `notificarClientes` after each upsert |
| `bimex-frontend/src/components/ListaProyectos.jsx` | `useEffect` subscribes to `EventSource`, reloads on any event, closes on unmount |
| `bimex-indexer/.env.example` | Added `FRONTEND_URL` |
| `bimex-frontend/.env.example` | Added `VITE_INDEXER_URL` |

Events emitted: `proyecto_actualizado`, `nueva_contribucion`, `yield_reclamado`.

**Test:** `curl -N http://localhost:3001/sse` — approve a project in AdminPanel and watch the event arrive without refreshing.

## #81 — Public changelog

| File | Change |
|---|---|
| `CHANGELOG.md` | New — Keep a Changelog format, v1.0.0 → v2.1.0 + Unreleased |
| `bimex-frontend/src/components/Changelog.jsx` | New — renders releases with color-coded sections |
| `bimex-frontend/src/App.jsx` | Novedades link in footer (authenticated + landing) |

## Tested
- `vite build` passes with no errors
- `node --input-type=module` validates `sse.js` imports cleanly