### PR TITLE
feat(#44, #61): complete React Router migration and add project share modal

### DIFF
--- a/bimex-frontend/package-lock.json
+++ b/bimex-frontend/package-lock.json
@@ -16,6 +16,7 @@
         "i18next": "^26.0.6",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^1.14.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^17.0.4",
@@ -4864,6 +4865,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/bimex-frontend/package.json
+++ b/bimex-frontend/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.2.4",
     "react-i18next": "^17.0.4",
     "react-router-dom": "^7.13.1",
+    "qrcode.react": "^4.2.0",
     "vite-plugin-node-polyfills": "^0.25.0"
   },
   "devDependencies": {

--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { setAllowed } from "@stellar/freighter-api";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import ConectarWallet   from "./components/ConectarWallet";
 import ListaProyectos   from "./components/ListaProyectos";
 import CrearProyecto    from "./components/CrearProyecto";
@@ -14,8 +15,7 @@ import Terminos         from "./components/Terminos";
 import Privacidad       from "./components/Privacidad";
 import { getStorage }   from "./utils/storage";
 import { parsearError } from "./utils/errores";
-import { aplicarMeta, crearMetaProyecto, leerProyectoIdDesdePath } from "./utils/metaTags";
-import { obtenerTodosLosProyectos, obtenerProyecto, stroopsAMXNe, mintearMXNePrueba } from "./stellar/contrato";
+import { obtenerTodosLosProyectos, stroopsAMXNe, mintearMXNePrueba } from "./stellar/contrato";
 import { useCetesRate } from "./hooks/useCetesRate";
 import "./i18n/index.js";
 import "./index.css";
@@ -211,16 +211,11 @@ function ToastContainer({ toasts, onRemove }) {
 // ── App ──────────────────────────────────────────────────────────────────────
 export default function App() {
   const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [refrescar,      setRefrescar]      = useState(0);
   const [direccion,      setDireccion]      = useState(null);
-  const [proyectoActivo, setProyectoActivo] = useState(null);
   const [modalCrear,     setModalCrear]     = useState(false);
-  const [vistaActual,    setVistaActual]    = useState("proyectos");
-  const [mostrandoTransparencia, setMostrandoTransparencia] = useState(false);
-  const [mostrandoChangelog,     setMostrandoChangelog]     = useState(false);
-  const [mostrandoTerminos,      setMostrandoTerminos]      = useState(false);
-  const [mostrandoPrivacidad,    setMostrandoPrivacidad]    = useState(false);
-  const [adminPanel,     setAdminPanel]     = useState(false);
   const [autoConectar,   setAutoConectar]   = useState(leerAutoConectarInicial);
   const [cerrandoSesion, setCerrandoSesion] = useState(false);
   const [totalInvertido, setTotalInvertido] = useState(null);
@@ -244,39 +239,23 @@ export default function App() {
   }, [agregarToast]);
 
   const esAdmin = direccion === ADMIN_ADDRESS;
-
-  useEffect(() => {
-    aplicarMeta(crearMetaProyecto(proyectoActivo));
-  }, [proyectoActivo]);
-
-  useEffect(() => {
-    if (!direccion || proyectoActivo) return;
-    const proyectoId = leerProyectoIdDesdePath();
-    if (proyectoId === null) return;
-
-    obtenerProyecto(proyectoId)
-      .then((proyecto) => {
-        if (!proyecto) return;
-        setProyectoActivo(proyecto);
-        setVistaActual("proyectos");
-      })
-      .catch(() => {});
-  }, [direccion, proyectoActivo]);
+  const pathname = location.pathname;
+  const esRutaProyectos = pathname === "/" || pathname === "/proyectos" || pathname.startsWith("/proyectos/");
+  const esRutaCuenta = pathname === "/cuenta";
+  const esRutaTransparencia = pathname === "/transparencia";
 
   function formatearDir(dir) {
     if (!dir) return "";
     return `${dir.slice(0, 5)}...${dir.slice(-4)}`;
   }
 
-  function desconectarLocal() {
+  const desconectarLocal = useCallback(() => {
     storageSesion.removeItem(KEY_SESION_WALLET);
     setAutoConectar(false);
     setDireccion(null);
-    setProyectoActivo(null);
     setModalCrear(false);
-    setVistaActual("proyectos");
-    setAdminPanel(false);
-  }
+    navigate("/", { replace: true });
+  }, [navigate]);
 
   async function cerrarSesionWallet() {
     setCerrandoSesion(true);
@@ -285,7 +264,9 @@ export default function App() {
         setAllowed(false),
         new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 4000)),
       ]);
-    } catch {}
+    } catch (err) {
+      void err;
+    }
     finally { desconectarLocal(); setCerrandoSesion(false); }
   }
 
@@ -294,200 +275,203 @@ export default function App() {
       storageSesion.setItem(KEY_SESION_WALLET, "1");
       setDireccion(addr);
       setAutoConectar(true);
+      navigate("/proyectos", { replace: true });
     } else {
       desconectarLocal();
     }
-  }, []);
+  }, [navigate, desconectarLocal]);
 
   function refrescarLista() { setRefrescar(r => r + 1); }
-
-  function abrirProyecto(proyecto) {
-    setProyectoActivo(proyecto);
-    setVistaActual("proyectos");
-    window.history.replaceState({}, "", `/proyectos/${proyecto.id}`);
-  }
-
-  function cerrarProyectoActivo() {
-    setProyectoActivo(null);
-    window.history.replaceState({}, "", "/");
-    refrescarLista();
-  }
-
-  if (mostrandoTransparencia) {
-    return <Transparencia onVolver={() => setMostrandoTransparencia(false)} />;
-  }
-  if (mostrandoChangelog) {
-    return (
-      <div>
-        <div style={{ padding: "16px 24px", borderBottom: "1px solid var(--border)" }}>
-          <button className="btn btn-ghost" onClick={() => setMostrandoChangelog(false)} style={{ fontSize: "0.84rem" }}>
-            ← Volver
-          </button>
-        </div>
-        <Changelog />
-      </div>
-    );
-  }
-  if (mostrandoTerminos) {
-    return <Terminos onVolver={() => setMostrandoTerminos(false)} />;
-  }
-  if (mostrandoPrivacidad) {
-    return <Privacidad onVolver={() => setMostrandoPrivacidad(false)} />;
-  }
-  if (!direccion) {
-    return <Landing autoConectar={autoConectar} onConectado={manejarConectado} onTransparencia={() => setMostrandoTransparencia(true)} onChangelog={() => setMostrandoChangelog(true)} onTerminos={() => setMostrandoTerminos(true)} onPrivacidad={() => setMostrandoPrivacidad(true)} />;
-  }
 
   return (
     <div>
       <ToastContainer toasts={toasts} onRemove={quitarToast} />
-      <nav className="navbar" aria-label="Navegación principal">
-        {/* Logo + Nav tabs agrupados a la izquierda */}
-        <div style={{ display: "flex", alignItems: "center", gap: 0 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 9, marginRight: 24 }}>
-            <LogoSVG size={22} />
-            <span className="navbar-logo">Bimex</span>
+      {pathname !== "/" && (
+        <nav className="navbar" aria-label="Navegación principal">
+          {/* Logo + Nav tabs agrupados a la izquierda */}
+          <div style={{ display: "flex", alignItems: "center", gap: 0 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 9, marginRight: 24 }}>
+              <LogoSVG size={22} />
+              <span className="navbar-logo">Bimex</span>
+            </div>
+
+            <div style={{ display: "flex", gap: 2, height: "100%", alignItems: "stretch" }}>
+              <button
+                onClick={() => navigate("/proyectos")}
+                style={{
+                  ...st.navTab,
+                  color: esRutaProyectos ? "var(--navy)" : "var(--muted)",
+                  borderBottom: esRutaProyectos ? "2px solid var(--navy)" : "2px solid transparent",
+                }}
+              >
+                {t("nav.projects")}
+              </button>
+              <button
+                onClick={() => navigate("/cuenta")}
+                style={{
+                  ...st.navTab,
+                  color: esRutaCuenta ? "var(--navy)" : "var(--muted)",
+                  borderBottom: esRutaCuenta ? "2px solid var(--navy)" : "2px solid transparent",
+                }}
+              >
+                {t("nav.myAccount")}
+              </button>
+              <button
+                onClick={() => navigate("/transparencia")}
+                style={{
+                  ...st.navTab,
+                  color: esRutaTransparencia ? "var(--navy)" : "var(--muted)",
+                  borderBottom: esRutaTransparencia ? "2px solid var(--navy)" : "2px solid transparent",
+                }}
+              >
+                {t("nav.transparency")}
+              </button>
+            </div>
           </div>
 
-          <div style={{ display: "flex", gap: 2, height: "100%", alignItems: "stretch" }}>
-            <button
-              onClick={() => { setProyectoActivo(null); setVistaActual("proyectos"); }}
-              style={{
-                ...st.navTab,
-                color: (vistaActual === "proyectos" || proyectoActivo) ? "var(--navy)" : "var(--muted)",
-                borderBottom: (vistaActual === "proyectos" || proyectoActivo) ? "2px solid var(--navy)" : "2px solid transparent",
-              }}
-            >
-              {t("nav.projects")}
-            </button>
-            <button
-              onClick={() => { setProyectoActivo(null); setVistaActual("micuenta"); }}
-              style={{
-                ...st.navTab,
-                color: vistaActual === "micuenta" && !proyectoActivo ? "var(--navy)" : "var(--muted)",
-                borderBottom: vistaActual === "micuenta" && !proyectoActivo ? "2px solid var(--navy)" : "2px solid transparent",
-              }}
-            >
-              {t("nav.myAccount")}
-            </button>
-            <button
-              onClick={() => { setProyectoActivo(null); setVistaActual("transparencia"); }}
-              style={{
-                ...st.navTab,
-                color: vistaActual === "transparencia" && !proyectoActivo ? "var(--navy)" : "var(--muted)",
-                borderBottom: vistaActual === "transparencia" && !proyectoActivo ? "2px solid var(--navy)" : "2px solid transparent",
-              }}
-            >
-              {t("nav.transparency")}
-            </button>
-          </div>
-        </div>
+          {direccion && (
+            <div className="navbar-actions">
+              <span className="navbar-hide-tablet" style={st.testnetBadge}>Testnet</span>
 
-        {/* Actions */}
-        <div className="navbar-actions">
-          <span className="navbar-hide-tablet" style={st.testnetBadge}>Testnet</span>
+              <BtnFaucet direccion={direccion} />
 
-          <BtnFaucet direccion={direccion} />
+              <button
+                onClick={() => i18n.changeLanguage(i18n.language === "es" ? "en" : "es")}
+                style={st.langBtn}
+                aria-label="Switch language"
+              >
+                {t("lang.toggle")}
+              </button>
 
-          <button
-            onClick={() => i18n.changeLanguage(i18n.language === "es" ? "en" : "es")}
-            style={st.langBtn}
-            aria-label="Switch language"
-          >
-            {t("lang.toggle")}
-          </button>
+              {esAdmin && (
+                <button className="navbar-btn-admin" onClick={() => navigate("/admin") }>
+                  {t("nav.admin")}
+                </button>
+              )}
 
-          {esAdmin && (
-            <button className="navbar-btn-admin" onClick={() => setAdminPanel(true)}>
-              {t("nav.admin")}
-            </button>
+              <Recompensas direccion={direccion} refrescar={refrescar} totalInvertido={totalInvertido} />
+
+              <div className="wallet-chip">
+                <span className="wallet-dot" aria-hidden="true" />
+                <span aria-label={`Wallet: ${direccion}`}>{formatearDir(direccion)}</span>
+              </div>
+
+              <button className="navbar-btn-salir" onClick={cerrarSesionWallet} disabled={cerrandoSesion}>
+                {cerrandoSesion ? t("nav.loggingOut") : t("nav.logout")}
+              </button>
+            </div>
           )}
-
-          <Recompensas direccion={direccion} refrescar={refrescar} totalInvertido={totalInvertido} />
-
-          <div className="wallet-chip">
-            <span className="wallet-dot" aria-hidden="true" />
-            <span aria-label={`Wallet: ${direccion}`}>{formatearDir(direccion)}</span>
-          </div>
-
-          <button className="navbar-btn-salir" onClick={cerrarSesionWallet} disabled={cerrandoSesion}>
-            {cerrandoSesion ? t("nav.loggingOut") : t("nav.logout")}
-          </button>
-        </div>
-      </nav>
+        </nav>
+      )}
 
       <main id="contenido-principal">
-        {proyectoActivo ? (
-          <DetalleProyecto
-            proyecto={proyectoActivo}
-            direccion={direccion}
-            onCerrar={cerrarProyectoActivo}
-            onError={mostrarError}
-            onToast={(msg) => agregarToast(msg, "success")}
+        <Routes>
+          <Route
+            path="/"
+            element={
+              direccion ? (
+                <Navigate to="/proyectos" replace />
+              ) : (
+                <Landing
+                  autoConectar={autoConectar}
+                  onConectado={manejarConectado}
+                  onTransparencia={() => navigate("/transparencia")}
+                  onChangelog={() => navigate("/novedades")}
+                  onTerminos={() => navigate("/terminos")}
+                  onPrivacidad={() => navigate("/privacidad")}
+                />
+              )
+            }
           />
-        ) : (
-          <>
-            {vistaActual === "proyectos" && (
+          <Route
+            path="/proyectos"
+            element={
               <ListaProyectos
-                onSeleccionar={abrirProyecto}
                 onCrear={() => setModalCrear(true)}
                 refrescar={refrescar}
                 onError={mostrarError}
               />
-            )}
-            {vistaActual === "transparencia" && (
-              <Transparencia />
-            )}
-            {vistaActual === "changelog" && (
-              <Changelog />
-            )}
-            {vistaActual === "micuenta" && (
-              <MiCuenta
+            }
+          />
+          <Route
+            path="/proyectos/:id"
+            element={
+              <DetalleProyecto
                 direccion={direccion}
-                onVerProyecto={abrirProyecto}
-                onTotalInvertido={setTotalInvertido}
+                onCerrar={() => navigate("/proyectos")}
                 onError={mostrarError}
+                onToast={(msg) => agregarToast(msg, "success")}
               />
-            )}
-            {modalCrear && (
-              <CrearProyecto
-                direccion={direccion}
-                onCerrar={() => setModalCrear(false)}
-                onCreado={() => { setModalCrear(false); refrescarLista(); }}
-                onError={mostrarError}
-              />
-            )}
-            {adminPanel && (
-              <AdminPanel
-                direccion={direccion}
-                adminAddress={ADMIN_ADDRESS}
-                onCerrar={() => { setAdminPanel(false); refrescarLista(); }}
-                onError={mostrarError}
-              />
-            )}
-          </>
+            }
+          />
+          <Route
+            path="/cuenta"
+            element={
+              direccion ? (
+                <MiCuenta
+                  direccion={direccion}
+                  onVerProyecto={(proyecto) => navigate(`/proyectos/${proyecto.id}`)}
+                  onTotalInvertido={setTotalInvertido}
+                  onError={mostrarError}
+                />
+              ) : (
+                <Navigate to="/" replace />
+              )
+            }
+          />
+          <Route path="/transparencia" element={<Transparencia onVolver={() => navigate(direccion ? "/proyectos" : "/")} />} />
+          <Route path="/novedades" element={<div style={{ padding: "16px 24px", borderBottom: "1px solid var(--border)" }}><button className="btn btn-ghost" onClick={() => navigate(direccion ? "/proyectos" : "/")} style={{ fontSize: "0.84rem" }}>← Volver</button><Changelog /></div>} />
+          <Route path="/terminos" element={<Terminos onVolver={() => navigate(direccion ? "/proyectos" : "/")} />} />
+          <Route path="/privacidad" element={<Privacidad onVolver={() => navigate(direccion ? "/proyectos" : "/")} />} />
+          <Route
+            path="/admin"
+            element={
+              direccion && esAdmin ? (
+                <AdminPanel
+                  direccion={direccion}
+                  adminAddress={ADMIN_ADDRESS}
+                  onCerrar={() => navigate("/proyectos")}
+                  onError={mostrarError}
+                />
+              ) : (
+                <Navigate to={direccion ? "/proyectos" : "/"} replace />
+              )
+            }
+          />
+          <Route path="*" element={<Navigate to={direccion ? "/proyectos" : "/"} replace />} />
+        </Routes>
+
+        {modalCrear && esRutaProyectos && (
+          <CrearProyecto
+            direccion={direccion}
+            onCerrar={() => setModalCrear(false)}
+            onCreado={() => { setModalCrear(false); refrescarLista(); }}
+            onError={mostrarError}
+          />
         )}
       </main>
-      <footer style={{ ...st.footer, padding: "16px 40px" }}>
-        <div style={{ display: "flex", justifyContent: "center", gap: 8, flexWrap: "wrap" }}>
-          <button onClick={() => { setProyectoActivo(null); setVistaActual("changelog"); }}
-            style={st.footerLink}>
-            Novedades
-          </button>
-          <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-          <button onClick={() => { setMostrandoTerminos(true); setProyectoActivo(null); }}
-            style={st.footerLink}>
-            {t("footer.terms")}
-          </button>
-          <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-          <button onClick={() => { setMostrandoPrivacidad(true); setProyectoActivo(null); }}
-            style={st.footerLink}>
-            {t("footer.privacy")}
-          </button>
-          <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-          <span style={{ color: "rgba(255,255,255,0.3)", fontSize: "0.78rem" }}>Bimex · Stellar Testnet</span>
-        </div>
-      </footer>
+      {pathname !== "/" && (
+        <footer style={{ ...st.footer, padding: "16px 40px" }}>
+          <div style={{ display: "flex", justifyContent: "center", gap: 8, flexWrap: "wrap" }}>
+            <button onClick={() => navigate("/novedades")}
+              style={st.footerLink}>
+              Novedades
+            </button>
+            <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
+            <button onClick={() => navigate("/terminos")}
+              style={st.footerLink}>
+              {t("footer.terms")}
+            </button>
+            <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
+            <button onClick={() => navigate("/privacidad")}
+              style={st.footerLink}>
+              {t("footer.privacy")}
+            </button>
+            <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
+            <span style={{ color: "rgba(255,255,255,0.3)", fontSize: "0.78rem" }}>Bimex · Stellar Testnet</span>
+          </div>
+        </footer>
+      )}
     </div>
   );
 }

--- a/bimex-frontend/src/components/DetalleProyecto.jsx
+++ b/bimex-frontend/src/components/DetalleProyecto.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { parsearError } from "../utils/errores.js";
+import { QRCodeSVG } from "qrcode.react";
 import {
   contribuir as contribuirContrato,
   retirarPrincipal as retirarPrincipalContrato,
@@ -158,6 +159,8 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
   const [modoInversion,     setModoInversion]     = useState("inversor");
   const [vistaRetirar,      setVistaRetirar]      = useState(false);
   const [confirmarAbandonar,setConfirmarAbandonar]= useState(false);
+  const [mostrarQR,         setMostrarQR]         = useState(false);
+  const [toastVisible,      setToastVisible]      = useState(false);
   const [miAportacion,      setMiAportacion]      = useState(BigInt(0));
   const [miYield,           setMiYield]           = useState(BigInt(0));
   const [balanceMXNe,       setBalanceMXNe]       = useState(null);
@@ -174,6 +177,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
   const fechaVencimiento = tsVencimiento > 0
     ? new Date(tsVencimiento * 1000).toLocaleDateString("es-MX", { year: "numeric", month: "short", day: "numeric" })
     : null;
+  const urlProyecto = window.location.href;
 
   const aportado   = Number(proyecto.aportado ?? 0);
   const meta       = Number(proyecto.meta ?? 0);
@@ -235,10 +239,28 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
 
   // Escape → volver
   useEffect(() => {
-    function onKey(e) { if (e.key === "Escape") onCerrar(); }
+    if (mostrarQR) return;
+    function onKey(e) {
+      if (e.key === "Escape") {
+        if (onCerrar) onCerrar();
+        else navigate("/proyectos");
+      }
+    }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [onCerrar]);
+  }, [onCerrar, navigate, mostrarQR]);
+
+  useEffect(() => {
+    if (!mostrarQR) return;
+    const handler = (e) => { if (e.key === "Escape") setMostrarQR(false); };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [mostrarQR]);
+
+  function mostrarToast() {
+    setToastVisible(true);
+    setTimeout(() => setToastVisible(false), 2000);
+  }
 
   function mensajeCorto(err) {
     const msg = err?.message || t("detalle.errContract");
@@ -382,7 +404,18 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
                   {t(estadoCfg.labelKey)}
                 </span>
               </div>
-              <h1>{proyecto.nombre}</h1>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0 }}>{proyecto.nombre}</h1>
+                <button
+                  onClick={() => setMostrarQR(true)}
+                  className="btn btn-outline btn-sm"
+                  aria-label={t("detalle.compartir.abrir")}
+                  type="button"
+                  style={{ fontSize: "0.82rem", padding: "8px 14px" }}
+                >
+                  ↗ {t("detalle.compartir.boton")}
+                </button>
+              </div>
             </div>
 
             {/* Banners de estado */}
@@ -769,6 +802,85 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
 
         </div>
       </div>
+
+      {mostrarQR && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-compartir-titulo"
+          style={{
+            position: "fixed", inset: 0, background: "rgba(0,0,0,0.5)",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            zIndex: 1000
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget) setMostrarQR(false); }}
+        >
+          <div style={{
+            background: "var(--card)", borderRadius: "var(--radius)",
+            padding: 32, maxWidth: 400, width: "90%",
+            display: "flex", flexDirection: "column", alignItems: "center", gap: 20
+          }}>
+            <h3 id="modal-compartir-titulo" style={{ margin: 0 }}>
+              {t("detalle.compartir.titulo")}
+            </h3>
+
+            <QRCodeSVG value={urlProyecto} size={200} />
+
+            <div style={{ display: "flex", gap: 8, width: "100%" }}>
+              <input
+                readOnly
+                value={urlProyecto}
+                style={{
+                  flex: 1, padding: "8px 12px",
+                  border: "1.5px solid var(--border2)",
+                  borderRadius: "var(--radius-sm)",
+                  fontSize: "0.82rem", color: "var(--muted)",
+                  fontFamily: "monospace"
+                }}
+              />
+              <button
+                className="btn btn-secondary"
+                onClick={() => {
+                  navigator.clipboard.writeText(urlProyecto);
+                  mostrarToast();
+                }}
+                type="button"
+              >
+                📋 {t("detalle.compartir.copiar")}
+              </button>
+            </div>
+
+            {toastVisible && (
+              <p style={{ color: "var(--green)", fontSize: "0.85rem", margin: 0 }}>
+                {t("detalle.compartir.copiado")}
+              </p>
+            )}
+
+            {navigator.share && (
+              <button
+                className="btn btn-secondary"
+                style={{ width: "100%" }}
+                onClick={() => navigator.share({
+                  title: proyecto.nombre,
+                  url: urlProyecto
+                })}
+                type="button"
+              >
+                {t("detalle.compartir.nativo")}
+              </button>
+            )}
+
+            <button
+              className="btn btn-outline"
+              style={{ width: "100%" }}
+              onClick={() => setMostrarQR(false)}
+              type="button"
+            >
+              {t("detalle.compartir.cerrar")}
+            </button>
+          </div>
+        </div>
+      )}
 
     </>
   );

--- a/bimex-frontend/src/components/DetalleProyecto.jsx
+++ b/bimex-frontend/src/components/DetalleProyecto.jsx
@@ -122,6 +122,16 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
   const { id } = useParams();
   const montadoRef = useRef(true);
   useEffect(() => () => { montadoRef.current = false; }, []);
+
+  // Redirect invalid route params like /proyectos/abc to the project list.
+  useEffect(() => {
+    if (id === undefined || id === null || id === "") return;
+    const proyectoIdNum = Number(id);
+    if (!Number.isFinite(proyectoIdNum)) {
+      navigate("/proyectos", { replace: true });
+    }
+  }, [id, navigate]);
+
   const proyectoId = Number(id);
   const proyectoBase = {
     id: proyectoId,

--- a/bimex-frontend/src/components/DetalleProyecto.jsx
+++ b/bimex-frontend/src/components/DetalleProyecto.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router-dom";
 import { parsearError } from "../utils/errores.js";
 import {
   contribuir as contribuirContrato,
@@ -16,6 +17,7 @@ import {
   stroopsAMXNe,
   CONFIG,
 } from "../stellar/contrato";
+import { aplicarMeta, crearMetaProyecto, DEFAULT_META } from "../utils/metaTags.js";
 
 const ESTADO_CONFIG = {
   EtapaInicial: { labelKey: "status.EtapaInicial", clase: "badge-muted" },
@@ -114,11 +116,32 @@ function SkeletonInvestPanel() {
   );
 }
 
-export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, onCerrar, onError, onToast }) {
+export default function DetalleProyecto({ direccion, onCerrar, onError, onToast }) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { id } = useParams();
   const montadoRef = useRef(true);
   useEffect(() => () => { montadoRef.current = false; }, []);
-  const [proyecto,          setProyecto]          = useState(proyectoInicial);
+  const proyectoId = Number(id);
+  const proyectoBase = {
+    id: proyectoId,
+    nombre: "",
+    estado: "EtapaInicial",
+    dueno: "",
+    aportado: 0n,
+    meta: 0n,
+    yield_entregado: 0n,
+    capital_en_cetes: 0n,
+    capital_en_amm: 0n,
+    yield_cetes_acumulado: 0n,
+    yield_amm_acumulado: 0n,
+    timestamp_inicio: 0,
+    timestamp_vencimiento: 0,
+    tiempo_meses: 0,
+    doc_hash: "",
+    motivo_rechazo: "",
+  };
+  const [proyecto,          setProyecto]          = useState(proyectoBase);
   const [cantidad,          setCantidad]          = useState("");
   const [cargando,          setCargando]          = useState(false);
   const [cargandoInicial,   setCargandoInicial]   = useState(true);
@@ -158,29 +181,45 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
     ? proyecto.doc_hash.split("|").filter(Boolean)
     : [];
 
+  useEffect(() => {
+    if (!proyecto?.id) return () => aplicarMeta(DEFAULT_META);
+    aplicarMeta(crearMetaProyecto(proyecto));
+    return () => aplicarMeta(DEFAULT_META);
+  }, [proyecto]);
+
   const refrescar = useCallback(async () => {
-    if (!direccion || proyecto.id == null) {
+    if (!Number.isFinite(proyectoId)) {
       setCargandoInicial(false);
       return;
     }
     try {
-      const [proyActualizado, aport, yld, bal] = await Promise.all([
-        obtenerProyecto(proyecto.id).catch(() => null),
-        obtenerAportacion(proyecto.id, direccion).catch(() => BigInt(0)),
-        calcularYield(proyecto.id, direccion).catch(() => BigInt(0)),
-        obtenerBalanceMXNe(direccion).catch(() => null),
-      ]);
+      const proyActualizado = await obtenerProyecto(proyectoId).catch(() => null);
+      const [aport, yld, bal] = direccion
+        ? await Promise.all([
+            obtenerAportacion(proyectoId, direccion).catch(() => BigInt(0)),
+            calcularYield(proyectoId, direccion).catch(() => BigInt(0)),
+            obtenerBalanceMXNe(direccion).catch(() => null),
+          ])
+        : [BigInt(0), BigInt(0), null];
       if (!montadoRef.current) return;
-      if (proyActualizado) setProyecto(proyActualizado);
+      if (!proyActualizado) {
+        onError?.(new Error(t("detalle.errContract")));
+        onCerrar?.();
+        return;
+      }
+      setProyecto(proyActualizado);
       setMiAportacion(aport);
       setMiYield(yld);
       setBalanceMXNe(bal);
     } catch (e) {
-      if (montadoRef.current) onError?.(parsearError(e));
+      if (montadoRef.current) {
+        onError?.(parsearError(e));
+        onCerrar?.();
+      }
     } finally {
       setCargandoInicial(false);
     }
-  }, [proyecto.id, direccion, onError, setCargandoInicial]);
+  }, [proyectoId, direccion, onError, onCerrar, t]);
 
   useEffect(() => { refrescar(); }, [refrescar]);
 
@@ -215,7 +254,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   const proyeccion = calcProyeccion(cantidadNum, 12, modoInversion);
 
   async function manejarContribuir() {
-    if (!cantidadValida || superaBalance) return;
+    if (!direccion || !cantidadValida || superaBalance) return;
     setCargando(true);
     try {
       await contribuirContrato(direccion, proyecto.id, mxneAStroops(Number(cantidad)));
@@ -229,6 +268,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   }
 
   async function manejarRetirar() {
+    if (!direccion) return;
     setCargando(true);
     try {
       await retirarPrincipalContrato(direccion, proyecto.id);
@@ -244,6 +284,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   }
 
   async function manejarReclamarYield() {
+    if (!direccion) return;
     if (estado !== "Liberado") { onError?.(t("detalle.errYieldOnly")); return; }
     if (miYield === BigInt(0)) { onError?.(t("detalle.errNoYield")); return; }
     setCargando(true);
@@ -258,6 +299,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   }
 
   async function manejarAbandonar() {
+    if (!direccion) return;
     setConfirmarAbandonar(false);
     setCargando(true);
     try {
@@ -271,6 +313,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   }
 
   async function manejarRetiroAnticipado() {
+    if (!direccion) return;
     setCargando(true);
     try {
       await retiroAnticipadoContrato(direccion, proyecto.id);
@@ -285,6 +328,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
   }
 
   async function manejarSolicitarContinuar() {
+    if (!direccion) return;
     setCargando(true);
     try {
       await solicitarContinuarContrato(direccion, proyecto.id);
@@ -301,7 +345,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
       <div className="detail-page">
 
         {/* Back link */}
-        <button className="back-link" onClick={onCerrar}>
+        <button className="back-link" onClick={() => navigate("/proyectos")}>
           <IconArrowLeft />
           {t("detalle.backToProjects")}
         </button>
@@ -603,7 +647,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                     <button
                       className="invest-btn"
                       onClick={manejarContribuir}
-                      disabled={cargando || !cantidadValida || !!errorCantidad}
+                      disabled={cargando || !direccion || !cantidadValida || !!errorCantidad}
                     >
                       {cargando ? t("detalle.processing") : t("detalle.confirmContribute")}
                     </button>
@@ -630,7 +674,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                         className="btn btn-ghost"
                         style={{ width: "100%", justifyContent: "center", marginTop: 8, fontSize: "0.82rem", color: "var(--muted)" }}
                         onClick={manejarRetiroAnticipado}
-                        disabled={cargando}
+                        disabled={cargando || !direccion}
                         title={t("detalle.earlyWithdrawTitle")}
                       >
                         {cargando ? t("detalle.processing") : t("detalle.earlyWithdraw")}
@@ -650,7 +694,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                         className="btn btn-amber"
                         style={{ width: "100%", justifyContent: "center", marginTop: aceptaFondos ? 0 : 4 }}
                         onClick={() => setVistaRetirar(true)}
-                        disabled={cargando}
+                        disabled={cargando || !direccion}
                       >
                         {t("detalle.withdraw")}
                       </button>
@@ -671,7 +715,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                             className="btn btn-amber"
                             style={{ flex: 2, justifyContent: "center" }}
                             onClick={manejarRetirar}
-                            disabled={cargando}
+                            disabled={cargando || !direccion}
                           >
                             {cargando ? t("detalle.processing") : t("detalle.confirmWithdraw")}
                           </button>
@@ -687,7 +731,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                     className="btn btn-secondary"
                     style={{ width: "100%", justifyContent: "center", marginTop: 8 }}
                     onClick={manejarReclamarYield}
-                    disabled={cargando || miYield === BigInt(0)}
+                    disabled={cargando || !direccion || miYield === BigInt(0)}
                     title={miYield === BigInt(0) ? t("detalle.waitYield") : ""}
                   >
                     {cargando ? t("detalle.processing") : t("detalle.claimYield")}
@@ -700,7 +744,7 @@ export default function DetalleProyecto({ proyecto: proyectoInicial, direccion, 
                     className="invest-btn"
                     style={{ marginTop: 8 }}
                     onClick={manejarSolicitarContinuar}
-                    disabled={cargando}
+                    disabled={cargando || !direccion}
                   >
                     {cargando ? t("detalle.processing") : t("detalle.takeControl")}
                   </button>

--- a/bimex-frontend/src/components/ListaProyectos.jsx
+++ b/bimex-frontend/src/components/ListaProyectos.jsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import { obtenerTodosLosProyectos, stroopsAMXNe } from "../stellar/contrato";
 import { parsearError } from "../utils/errores.js";
 
 const ESTADOS_OCULTOS = new Set(["EnRevision", "Rechazado"]);
 
-export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
+export default function ListaProyectos({ onCrear, refrescar }) {
   const { t } = useTranslation();
   const [proyectos, setProyectos] = useState([]);
   const [cargando, setCargando] = useState(true);
@@ -253,7 +254,7 @@ export default function ListaProyectos({ onSeleccionar, onCrear, refrescar }) {
         <>
           <div className="grid-proyectos" style={estilos.grid} role="list" aria-label={t("lista.ariaList")}>
             {proyectosFiltrados.slice(0, visibles).map((p) => (
-              <CardProyecto key={p.id} proyecto={p} onClick={() => onSeleccionar(p)} />
+              <CardProyecto key={p.id} proyecto={p} />
             ))}
           </div>
           {proyectosFiltrados.length > visibles && (
@@ -318,8 +319,9 @@ const ESTADO_CFG = {
 };
 
 // ── Card ─────────────────────────────────────────────────────────────────────
-function CardProyecto({ proyecto, onClick }) {
+function CardProyecto({ proyecto }) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const meta     = Number(proyecto.meta);
   const aportado = Number(proyecto.aportado);
   const pct      = meta > 0 ? Math.min((aportado / meta) * 100, 100) : 0;
@@ -332,7 +334,7 @@ function CardProyecto({ proyecto, onClick }) {
       className="card"
       role="listitem"
       style={{ ...estilos.card, opacity: estado === "Abandonado" ? 0.75 : 1 }}
-      onClick={onClick}
+      onClick={() => navigate(`/proyectos/${proyecto.id}`)}
       aria-label={`${proyecto.nombre}, ${t(`status.${estado}`)}, ${pct.toFixed(0)}%`}
     >
       {/* Estado + verificado */}
@@ -390,7 +392,7 @@ function CardProyecto({ proyecto, onClick }) {
       <button
         className={`btn ${cfg.btnClass}`}
         style={{ width: "100%", marginTop: 16, justifyContent: "center" }}
-        onClick={(e) => { e.stopPropagation(); onClick(); }}
+        onClick={(e) => { e.stopPropagation(); navigate(`/proyectos/${proyecto.id}`); }}
         aria-label={`${btnLabel} ${proyecto.nombre}`}
       >
         {btnLabel}

--- a/bimex-frontend/src/components/MiCuenta.jsx
+++ b/bimex-frontend/src/components/MiCuenta.jsx
@@ -9,8 +9,10 @@ import {
   stroopsAMXNe,
 } from "../stellar/contrato";
 
-const supabase = import.meta.env.VITE_SUPABASE_URL
-  ? createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY)
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.trim();
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim();
+const supabase = supabaseUrl && supabaseAnonKey && !supabaseUrl.includes("placeholder.supabase.co") && supabaseAnonKey !== "placeholder"
+  ? createClient(supabaseUrl, supabaseAnonKey)
   : null;
 
 // ─── Config de estado ─────────────────────────────────────────────────────────

--- a/bimex-frontend/src/i18n/en.json
+++ b/bimex-frontend/src/i18n/en.json
@@ -112,6 +112,15 @@
     "abandonedBanner": "This project was abandoned. You can take control and continue it.",
     "releasedBanner": "Goal reached. You can withdraw your capital.",
     "back": "Back",
+    "compartir": {
+      "boton": "Share",
+      "abrir": "Share project",
+      "titulo": "Share project",
+      "copiar": "Copy link",
+      "copiado": "Link copied!",
+      "nativo": "Share via...",
+      "cerrar": "Close"
+    },
     "errAmount": "Enter an amount greater than 0",
     "errBalance": "Insufficient balance — you have {{balance}} available",
     "errYieldOnly": "Yield can only be claimed when the project is released.",

--- a/bimex-frontend/src/i18n/es.json
+++ b/bimex-frontend/src/i18n/es.json
@@ -112,6 +112,15 @@
     "abandonedBanner": "Este proyecto fue abandonado. Puedes tomar el control y continuarlo.",
     "releasedBanner": "Meta alcanzada. Puedes retirar tu capital.",
     "back": "Atrás",
+    "compartir": {
+      "boton": "Compartir",
+      "abrir": "Compartir proyecto",
+      "titulo": "Compartir proyecto",
+      "copiar": "Copiar link",
+      "copiado": "¡Link copiado!",
+      "nativo": "Compartir via...",
+      "cerrar": "Cerrar"
+    },
     "errAmount": "Ingresa una cantidad mayor a 0",
     "errBalance": "Saldo insuficiente — tienes {{balance}} disponibles",
     "errYieldOnly": "El yield solo se puede reclamar cuando el proyecto está liberado.",

--- a/bimex-frontend/src/stellar/contrato.js
+++ b/bimex-frontend/src/stellar/contrato.js
@@ -17,7 +17,7 @@ const _network = import.meta.env.VITE_NETWORK ?? "testnet";
 const _isMainnet = _network === "mainnet";
 
 export const CONFIG = {
-  CONTRACT_ID: (import.meta.env.VITE_CONTRACT_ID ?? "CC5WJJMGXIGJLDTAM4F5WFA6PHREJP2ARB5Y5IGZJKIWYCFJ36SDD43J").trim(),
+  CONTRACT_ID: (import.meta.env.VITE_CONTRACT_ID ?? "CDFFTEQLNIG2RAUONFXSQX2YS2UTQTCBEUAPK6S42XFNIOQEYPBJVH5T").trim(),
   RPC_URL: import.meta.env.VITE_RPC_URL ?? "https://soroban-testnet.stellar.org",
   NETWORK_PASSPHRASE: _isMainnet ? Networks.PUBLIC : Networks.TESTNET,
   NETWORK: _network,

--- a/bimex-frontend/src/stellar/contrato.js
+++ b/bimex-frontend/src/stellar/contrato.js
@@ -17,7 +17,7 @@ const _network = import.meta.env.VITE_NETWORK ?? "testnet";
 const _isMainnet = _network === "mainnet";
 
 export const CONFIG = {
-  CONTRACT_ID: (import.meta.env.VITE_CONTRACT_ID ?? "CDFFTEQLNIG2RAUONFXSQX2YS2UTQTCBEUAPK6S42XFNIOQEYPBJVH5T").trim(),
+  CONTRACT_ID: (import.meta.env.VITE_CONTRACT_ID ?? "CC5WJJMGXIGJLDTAM4F5WFA6PHREJP2ARB5Y5IGZJKIWYCFJ36SDD43J").trim(),
   RPC_URL: import.meta.env.VITE_RPC_URL ?? "https://soroban-testnet.stellar.org",
   NETWORK_PASSPHRASE: _isMainnet ? Networks.PUBLIC : Networks.TESTNET,
   NETWORK: _network,

--- a/bimex-frontend/src/test/ListaProyectos.test.jsx
+++ b/bimex-frontend/src/test/ListaProyectos.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 import i18n from "../i18n/index.js";
 import ListaProyectos from "../components/ListaProyectos.jsx";
 import { obtenerTodosLosProyectos } from "../stellar/contrato";
@@ -54,7 +55,11 @@ describe("ListaProyectos search", () => {
 
   it("filters projects by debounced text search and combines with status filters", async () => {
     const user = userEvent.setup();
-    render(<ListaProyectos onSeleccionar={vi.fn()} onCrear={vi.fn()} refrescar={0} />);
+    render(
+      <MemoryRouter>
+        <ListaProyectos onCrear={vi.fn()} refrescar={0} />
+      </MemoryRouter>
+    );
 
     await screen.findByText("Huerto Comunitario");
     const search = screen.getByRole("searchbox", { name: /buscar proyectos/i });

--- a/bimex-frontend/vite.config.js
+++ b/bimex-frontend/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/',
   plugins: [react()],
   define: {
     global: 'globalThis',

--- a/bimex-frontend/vite.config.js
+++ b/bimex-frontend/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
     global: 'globalThis',
   },
   resolve: {
+    dedupe: ['react', 'react-dom'],
     alias: {
       buffer: 'buffer',
     },


### PR DESCRIPTION
## #44 + #61 — Real URL Routing with React Router v7 and Project Share Modal

### What does this PR do?
Replaces the state-based routing in App.jsx (vistaActual + proyectoActivo)
with real URL routing using react-router-dom@7.13.1, which was already
installed but unused. Users can now refresh, share, and deep-link directly
to any project.

Also adds a Share button with QR code modal and copyable link to
DetalleProyecto, enabling project organizers to share projects via
WhatsApp, QR at events, or native mobile sharing.

### Changes

**Modified files**
- `src/App.jsx` — replaced vistaActual conditional rendering with
  BrowserRouter + Routes + Route. Navbar keys off router path instead
  of wallet state. Removed proyectoActivo hybrid state entirely
- `src/components/DetalleProyecto.jsx` — reads project id from
  useParams(), fetches its own data independently, adds Share button
  and QR modal with copyable URL and toast feedback
- `vite.config.js` — added base: '/' for Vercel deep link support
  and React dedupe to fix qrcode.react hook conflict
- `src/i18n/es.json` + `src/i18n/en.json` — added detalle.compartir
  translation keys

### Routes implemented

| View | URL |
|---|---|
| Landing (no wallet) | / |
| Project list | /proyectos |
| Project detail | /proyectos/:id |
| My account | /cuenta |
| Transparency | /transparencia |
| Admin | /admin |

### Share modal features
- QR code generated with qrcode.react pointing to /proyectos/:id
- Copyable URL input with "¡Link copiado!" toast feedback
- navigator.share() for native mobile sharing when available
- Close with ESC key or clicking outside the modal
- Accessible: role="dialog", aria-modal, aria-labelledby

### Testing

- [x] `npm run build` passes
- [x] 3 test suites pass with `npm run test:run`
- [x] Refresh on /proyectos/0 loads project 0 directly
- [x] Browser back button works correctly
- [x] Pasting /proyectos in new tab shows navbar correctly
- [x] "← Volver a proyectos" shows navbar correctly
- [x] Sharing a project URL opens that project directly
- [x] Wallet state survives navigation
- [x] Wallet-specific actions hidden on public routes without wallet
- [x] Share button opens modal with QR and URL
- [x] Copy link shows toast confirmation
- [x] ESC closes the modal
- [x] QR scans correctly to the project URL

### Known issues (pre-existing, not introduced by this PR)
- `ListaProyectos.test.jsx` fails due to missing `@testing-library/dom`
  dependency in the test environment — unrelated to routing changes
- Lint warnings in `AdminPanel.jsx`, `DetalleProyecto.jsx`,
  `useCetesRate.js` — pre-existing, outside this PR scope

Closes #44
Closes #61