### PR TITLE
feat: agregar emergency pause / circuit breaker (#54)

### DIFF
--- a/bimex/contracts/bimex/src/lib.rs
+++ b/bimex/contracts/bimex/src/lib.rs
@@ -97,6 +97,7 @@ pub enum Clave {
     ContadorProyectos,
     Proyecto(u32),
     Aportacion(u32, Address),
+    Pausado,
 }
 
 // ============================================================
@@ -126,6 +127,11 @@ fn calcular_yield_seguro(capital: i128, bps: i128, minutos: i128) -> i128 {
     const MINUTOS_ANO: i128 = 525_600;
     (capital / MINUTOS_ANO) * bps / 10_000 * minutos
         + (capital % MINUTOS_ANO) * bps / 10_000 * minutos / MINUTOS_ANO
+}
+
+fn verificar_no_pausado(env: &Env) {
+    let pausado: bool = env.storage().instance().get(&Clave::Pausado).unwrap_or(false);
+    assert!(!pausado, "Contrato pausado por el administrador");
 }
 
 // ============================================================
@@ -176,9 +182,10 @@ impl BimexContrato {
         doc_cid: String,
         tiempo_meses: u32,
     ) -> u32 {
+        verificar_no_pausado(&env);
         dueno.require_auth();
         assert!(meta > 0, "La meta debe ser mayor a 0");
-        assert!(tiempo_meses >= 1 && tiempo_meses <= 120, "El tiempo debe estar entre 1 y 120 meses");
+        assert!((1..=120).contains(&tiempo_meses), "El tiempo debe estar entre 1 y 120 meses");
 
         let id: u32 = env.storage().instance().get(&Clave::ContadorProyectos).unwrap_or(0);
 
@@ -217,6 +224,7 @@ impl BimexContrato {
     /// - Top-ups preservan el timestamp original del backer.
     /// - No se aceptan contribuciones si el plazo de recaudación ya venció.
     pub fn contribuir(env: Env, backer: Address, id_proyecto: u32, cantidad: i128) {
+        verificar_no_pausado(&env);
         // AUTH FIRST
         backer.require_auth();
         assert!(cantidad > 0, "Cantidad debe ser mayor a 0");
@@ -272,7 +280,7 @@ impl BimexContrato {
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
 
         // INTERACTION last
-        token.transfer(&backer, &env.current_contract_address(), &cantidad);
+        token.transfer(&backer, env.current_contract_address(), &cantidad);
     }
 
     /// Calcula el yield pendiente de un backer específico en stroops.
@@ -333,6 +341,7 @@ impl BimexContrato {
     /// Resetea `timestamp_inicio` al momento actual para el próximo período.
     /// Retorna el monto de yield transferido en stroops.
     pub fn reclamar_yield(env: Env, id_proyecto: u32) -> i128 {
+        verificar_no_pausado(&env);
         let mut proyecto: Proyecto = env
             .storage().persistent().get(&Clave::Proyecto(id_proyecto))
             .expect("Proyecto no existe");
@@ -386,6 +395,7 @@ impl BimexContrato {
     /// ya fue o puede ser reclamado por el dueño vía `reclamar_yield`.
     /// Retorna el monto retirado en stroops.
     pub fn retirar_principal(env: Env, backer: Address, id_proyecto: u32) -> i128 {
+        verificar_no_pausado(&env);
         // AUTH FIRST
         backer.require_auth();
 
@@ -524,6 +534,7 @@ impl BimexContrato {
     /// Resetea `timestamp_inicio` para que el nuevo dueño no herede
     /// yield acumulado del período anterior.
     pub fn solicitar_continuar(env: Env, nuevo_dueno: Address, id_proyecto: u32) {
+        verificar_no_pausado(&env);
         // AUTH FIRST
         nuevo_dueno.require_auth();
 
@@ -599,6 +610,20 @@ impl BimexContrato {
 
     pub fn total_proyectos(env: Env) -> u32 {
         env.storage().instance().get(&Clave::ContadorProyectos).unwrap_or(0)
+    }
+
+    pub fn admin_pausar(env: Env, admin: Address) {
+        admin.require_auth();
+        let admin_guardado: Address = env.storage().instance().get(&Clave::Admin).expect("No inicializado");
+        assert!(admin == admin_guardado, "Solo el admin puede pausar");
+        env.storage().instance().set(&Clave::Pausado, &true);
+    }
+
+    pub fn admin_reanudar(env: Env, admin: Address) {
+        admin.require_auth();
+        let admin_guardado: Address = env.storage().instance().get(&Clave::Admin).expect("No inicializado");
+        assert!(admin == admin_guardado, "Solo el admin puede reanudar");
+        env.storage().instance().set(&Clave::Pausado, &false);
     }
 }
 

--- a/bimex/contracts/bimex/src/test.rs
+++ b/bimex/contracts/bimex/src/test.rs
@@ -762,3 +762,86 @@ fn test_yield_no_es_demo_exagerado() {
     assert!(detalle.cetes < 100_000_000, "CETES parece tasa demo: {} stroops", detalle.cetes);
     assert!(detalle.amm   < 100_000_000, "AMM parece tasa demo: {} stroops",   detalle.amm);
 }
+
+// ============================================================
+//  CIRCUIT BREAKER TESTS
+// ============================================================
+
+#[test]
+#[should_panic(expected = "Contrato pausado por el administrador")]
+fn test_pausa_bloquea_contribuciones() {
+    let (env, cliente, admin, dueno, backer) = setup();
+    let id = cliente.crear_proyecto(&dueno, &String::from_str(&env, "Test"), &100_000_000i128, &doc_cid_vacio(&env), &6u32);
+    cliente.admin_aprobar(&id);
+
+    // Contribuir antes de pausar
+    cliente.contribuir(&backer, &id, &10_000_000i128);
+
+    // Pausar contrato
+    cliente.admin_pausar(&admin);
+
+    // Las funciones de lectura deben seguir funcionando
+    let p_read = cliente.obtener_proyecto(&id);
+    assert_eq!(p_read.estado, EstadoProyecto::EnProgreso);
+    let yield_read = cliente.calcular_yield(&id, &backer);
+    assert_eq!(yield_read, 0);
+    let yield_det = cliente.calcular_yield_detallado(&id);
+    assert_eq!(yield_det.total, 0);
+    let capital = cliente.estado_capital(&id);
+    assert_eq!(capital.total, 10_000_000i128);
+
+    // Intentar contribuir - debe fallar
+    cliente.contribuir(&backer, &id, &10_000_000i128);
+}
+
+#[test]
+fn test_reanudacion_permite_contribuciones() {
+    let (env, cliente, admin, dueno, backer) = setup();
+    let id = cliente.crear_proyecto(&dueno, &String::from_str(&env, "Test"), &100_000_000i128, &doc_cid_vacio(&env), &6u32);
+    cliente.admin_aprobar(&id);
+
+    // Pausar
+    cliente.admin_pausar(&admin);
+
+    // Reanudar
+    cliente.admin_reanudar(&admin);
+
+    // Contribuir debe funcionar ahora
+    cliente.contribuir(&backer, &id, &10_000_000i128);
+    
+    let p = cliente.obtener_proyecto(&id);
+    assert_eq!(p.total_aportado, 10_000_000i128);
+}
+
+#[test]
+#[should_panic(expected = "Solo el admin puede pausar")]
+fn test_solo_admin_puede_pausar() {
+    let (env, cliente, _admin, _dueno, backer) = setup();
+    cliente.admin_pausar(&backer);
+}
+
+#[test]
+#[should_panic(expected = "Solo el admin puede reanudar")]
+fn test_solo_admin_puede_reanudar() {
+    let (env, cliente, _admin, _dueno, backer) = setup();
+    cliente.admin_reanudar(&backer);
+}
+
+#[test]
+fn test_admin_aprobacion_funciona_pausado() {
+    let (env, cliente, admin, dueno, _backer) = setup();
+    
+    let id_aprobar = cliente.crear_proyecto(&dueno, &String::from_str(&env, "Test 1"), &100_000_000i128, &doc_cid_vacio(&env), &6u32);
+    let id_rechazar = cliente.crear_proyecto(&dueno, &String::from_str(&env, "Test 2"), &100_000_000i128, &doc_cid_vacio(&env), &6u32);
+    
+    // Pausar
+    cliente.admin_pausar(&admin);
+    
+    // Aprobar/Rechazar - debe funcionar
+    cliente.admin_aprobar(&id_aprobar);
+    cliente.admin_rechazar(&id_rechazar, &String::from_str(&env, "Motivo"));
+    
+    assert_eq!(cliente.obtener_proyecto(&id_aprobar).estado, EstadoProyecto::EtapaInicial);
+    assert_eq!(cliente.obtener_proyecto(&id_rechazar).estado, EstadoProyecto::Rechazado);
+}
+


### PR DESCRIPTION
## Descripción

Implementa el circuit breaker / emergency pause para el contrato Bimex, resolviendo el issue #54.

Ante un bug crítico en producción, el admin ahora puede detener todas las operaciones de escritura en segundos sin necesidad de re-deploy ni migración manual de estado.

---

## Cambios

### `bimex/contracts/bimex/src/lib.rs`

- **`Clave::Pausado`** — nueva variante en el enum `Clave` para persistir el estado de pausa en instance storage.
- **`verificar_no_pausado(&env)`** — helper privado que lee el flag `Pausado` y hace panic con `"Contrato pausado por el administrador"` si está activo.
- **`admin_pausar(env, admin)`** — función pública que verifica `require_auth()` y que el caller es el admin guardado, luego setea `Pausado = true`.
- **`admin_reanudar(env, admin)`** — función pública con la misma verificación, setea `Pausado = false`.
- **Guard en funciones de escritura** — `verificar_no_pausado(&env)` agregado al inicio de:
  - `crear_proyecto`
  - `contribuir`
  - `reclamar_yield`
  - `retirar_principal`
  - `solicitar_continuar`
- **Funciones de lectura sin restricción** — `obtener_proyecto`, `calcular_yield`, `calcular_yield_detallado`, `estado_capital` siguen funcionando mientras el contrato esté pausado.
- **Admin sin restricción** — `admin_aprobar` y `admin_rechazar` siguen operando mientras el contrato esté pausado.
- **Corrección clippy** — `(1..=120).contains(&tiempo_meses)` en lugar de la comparación manual, y borrow innecesario eliminado en `contribuir`.

### `bimex/contracts/bimex/src/test.rs`

5 nuevos tests (sección `CIRCUIT BREAKER TESTS`):

| Test | Descripción |
|------|-------------|
| `test_pausa_bloquea_contribuciones` | Verifica que `contribuir` falla con el mensaje correcto cuando el contrato está pausado. También valida que las funciones de lectura siguen funcionando. |
| `test_reanudacion_permite_contribuciones` | Pausa y reanuda el contrato; verifica que `contribuir` vuelve a funcionar. |
| `test_solo_admin_puede_pausar` | Verifica que una address no-admin no puede llamar `admin_pausar`. |
| `test_solo_admin_puede_reanudar` | Verifica que una address no-admin no puede llamar `admin_reanudar`. |
| `test_admin_aprobacion_funciona_pausado` | Verifica que el admin puede aprobar y rechazar proyectos incluso con el contrato pausado. |

---

## Resultados

```
cargo test
running 52 tests
test result: ok. 52 passed; 0 failed; 0 ignored
```

```
cargo clippy -- -D warnings
Finished `dev` profile — sin errores ni warnings
```

---

## Criterios de aceptación ✅

- [x] `cargo test` pasa con 0 fallos (52 tests: 47 existentes + 5 nuevos)
- [x] El estado `Pausado` es persistente entre llamadas (instance storage)
- [x] Las funciones de lectura (`obtener_proyecto`, `calcular_yield`, `calcular_yield_detallado`, `estado_capital`) siguen funcionando mientras está pausado
- [x] Solo el admin puede pausar/reanudar (cualquier otra address falla)
- [x] El admin puede seguir aprobando/rechazando proyectos mientras está pausado
- [x] `cargo clippy -- -D warnings` sin errores

---

Closes #54
