### PR TITLE
feat(frontend): add WCAG-friendly ARIA, lang updates, dev axe integration, and accessibility test

### DIFF
--- a/bimex-frontend/package-lock.json
+++ b/bimex-frontend/package-lock.json
@@ -24,6 +24,7 @@
         "vite-plugin-node-polyfills": "^0.25.0"
       },
       "devDependencies": {
+        "@axe-core/react": "^4.5.0",
         "@eslint/js": "^9.39.4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -99,6 +100,17 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/react": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.11.3.tgz",
+      "integrity": "sha512-G7TrxptKNFfrQZ+Iygb8nGx5w8Su0jIjwmtVN/9Jc4G6RumCh1rD3pZRT2NzZKjT70q4BReuWVwEazS3HxFfjg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4",
+        "requestidlecallback": "^0.3.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1880,6 +1892,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -5038,6 +5060,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/bimex-frontend/package.json
+++ b/bimex-frontend/package.json
@@ -29,6 +29,7 @@
     "vite-plugin-node-polyfills": "^0.25.0"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.5.0",
     "@eslint/js": "^9.39.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -167,22 +167,31 @@ function BtnFaucet({ direccion }) {
 function ToastContainer({ toasts, onRemove }) {
   if (!toasts.length) return null;
   return (
-    <div style={{
-      position: "fixed", top: 16, right: 16, zIndex: 9999,
-      display: "flex", flexDirection: "column", gap: 10,
-      maxWidth: 380, width: "calc(100vw - 32px)",
-    }}>
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      style={{
+        position: "fixed", top: 16, right: 16, zIndex: 9999,
+        display: "flex", flexDirection: "column", gap: 10,
+        maxWidth: 380, width: "calc(100vw - 32px)",
+      }}
+    >
       {toasts.map(t => (
-        <div key={t.id} style={{
-          background: t.tipo === "error" ? "#FEF2F2" : "#F0FDF4",
-          border: `1px solid ${t.tipo === "error" ? "rgba(220,38,38,0.20)" : "rgba(22,163,74,0.20)"}`,
-          borderLeft: `4px solid ${t.tipo === "error" ? "#DC2626" : "var(--green)"}`,
-          borderRadius: "var(--radius-sm)",
-          padding: "12px 14px",
-          boxShadow: "var(--shadow-md)",
-          display: "flex", alignItems: "flex-start", gap: 10,
-          animation: "slideInRight 0.22s ease",
-        }}>
+        <div
+          key={t.id}
+          role={t.tipo === "error" ? "alert" : "status"}
+          aria-live={t.tipo === "error" ? "assertive" : "polite"}
+          aria-atomic="true"
+          style={{
+            background: t.tipo === "error" ? "#FEF2F2" : "#F0FDF4",
+            border: `1px solid ${t.tipo === "error" ? "rgba(220,38,38,0.20)" : "rgba(22,163,74,0.20)"}`,
+            borderLeft: `4px solid ${t.tipo === "error" ? "#DC2626" : "var(--green)"}`,
+            borderRadius: "var(--radius-sm)",
+            padding: "12px 14px",
+            boxShadow: "var(--shadow-md)",
+            display: "flex", alignItems: "flex-start", gap: 10,
+            animation: "slideInRight 0.22s ease",
+          }}>
           {/* Icono */}
           <div style={{ flexShrink: 0, marginTop: 1 }}>
             {t.tipo === "error" ? (
@@ -255,6 +264,10 @@ export default function App() {
       localStorage.setItem("tema", tema);
     }
   }, [tema]);
+
+  useEffect(() => {
+    document.documentElement.lang = i18n.language || "es";
+  }, [i18n.language]);
 
   // ── Toast system ───────────────────────────────────────────────────────────
   const [toasts, setToasts] = useState([]);
@@ -333,32 +346,38 @@ export default function App() {
 
             <div style={{ display: "flex", gap: 2, height: "100%", alignItems: "stretch" }}>
               <button
+                type="button"
                 onClick={() => navigate("/proyectos")}
                 style={{
                   ...st.navTab,
                   color: esRutaProyectos ? "var(--navy)" : "var(--muted)",
                   borderBottom: esRutaProyectos ? "2px solid var(--navy)" : "2px solid transparent",
                 }}
+                aria-current={esRutaProyectos ? "page" : undefined}
               >
                 {t("nav.projects")}
               </button>
               <button
+                type="button"
                 onClick={() => navigate("/cuenta")}
                 style={{
                   ...st.navTab,
                   color: esRutaCuenta ? "var(--navy)" : "var(--muted)",
                   borderBottom: esRutaCuenta ? "2px solid var(--navy)" : "2px solid transparent",
                 }}
+                aria-current={esRutaCuenta ? "page" : undefined}
               >
                 {t("nav.myAccount")}
               </button>
               <button
+                type="button"
                 onClick={() => navigate("/transparencia")}
                 style={{
                   ...st.navTab,
                   color: esRutaTransparencia ? "var(--navy)" : "var(--muted)",
                   borderBottom: esRutaTransparencia ? "2px solid var(--navy)" : "2px solid transparent",
                 }}
+                aria-current={esRutaTransparencia ? "page" : undefined}
               >
                 {t("nav.transparency")}
               </button>
@@ -370,6 +389,7 @@ export default function App() {
               <span className="navbar-hide-tablet" style={st.testnetBadge}>Testnet</span>
 
               <button
+                type="button"
                 onClick={() => setTema(t => t === 'dark' ? 'light' : 'dark')}
                 style={st.langBtn}
                 aria-label={t(tema === 'dark' ? "tema.claro" : "tema.oscuro")}
@@ -380,15 +400,16 @@ export default function App() {
               <BtnFaucet direccion={direccion} />
 
               <button
+                type="button"
                 onClick={() => i18n.changeLanguage(i18n.language === "es" ? "en" : "es")}
                 style={st.langBtn}
-                aria-label="Switch language"
+                aria-label={t("lang.toggleAria")}
               >
                 {t("lang.toggle")}
               </button>
 
               {esAdmin && (
-                <button className="navbar-btn-admin" onClick={() => navigate("/admin") }>
+                <button type="button" className="navbar-btn-admin" onClick={() => navigate("/admin") }>
                   {t("nav.admin")}
                 </button>
               )}
@@ -402,7 +423,7 @@ export default function App() {
                 <span aria-label={`Wallet: ${direccion}`}>{formatearDir(direccion)}</span>
               </div>
 
-              <button className="navbar-btn-salir" onClick={cerrarSesionWallet} disabled={cerrandoSesion}>
+              <button type="button" className="navbar-btn-salir" onClick={cerrarSesionWallet} disabled={cerrandoSesion}>
                 {cerrandoSesion ? t("nav.loggingOut") : t("nav.logout")}
               </button>
             </div>
@@ -475,7 +496,7 @@ export default function App() {
               </Suspense>
             }
           />
-          <Route path="/novedades" element={<div style={{ padding: "16px 24px", borderBottom: "1px solid var(--border)" }}><button className="btn btn-ghost" onClick={() => navigate(direccion ? "/proyectos" : "/")} style={{ fontSize: "0.84rem" }}>← Volver</button><Changelog /></div>} />
+          <Route path="/novedades" element={<div style={{ padding: "16px 24px", borderBottom: "1px solid var(--border)" }}><button type="button" className="btn btn-ghost" onClick={() => navigate(direccion ? "/proyectos" : "/")} style={{ fontSize: "0.84rem" }}>← Volver</button><Changelog /></div>} />
           <Route path="/terminos" element={<Terminos onVolver={() => navigate(direccion ? "/proyectos" : "/")} />} />
           <Route path="/privacidad" element={<Privacidad onVolver={() => navigate(direccion ? "/proyectos" : "/")} />} />
           <Route
@@ -512,22 +533,22 @@ export default function App() {
       {pathname !== "/" && (
         <footer style={{ ...st.footer, padding: "16px 40px" }}>
           <div style={{ display: "flex", justifyContent: "center", gap: 8, flexWrap: "wrap" }}>
-            <button onClick={() => navigate("/novedades")}
+            <button type="button" onClick={() => navigate("/novedades")}
               style={st.footerLink}>
               Novedades
             </button>
             <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-            <button onClick={() => navigate("/terminos")}
+            <button type="button" onClick={() => navigate("/terminos")}
               style={st.footerLink}>
               {t("footer.terms")}
             </button>
             <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-            <button onClick={() => navigate("/privacidad")}
+            <button type="button" onClick={() => navigate("/privacidad")}
               style={st.footerLink}>
               {t("footer.privacy")}
             </button>
             <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-            <span style={{ color: "rgba(255,255,255,0.3)", fontSize: "0.78rem" }}>Bimex · Stellar Testnet</span>
+            <span style={{ color: "rgba(255,255,255,0.65)", fontSize: "0.78rem" }}>Bimex · Stellar Testnet</span>
           </div>
         </footer>
       )}
@@ -569,6 +590,7 @@ function Landing({ autoConectar, onConectado, onTransparencia, onChangelog, onTe
           </button>
 
           <button
+            type="button"
             onClick={onTransparencia}
             style={{ background: "none", border: "none", cursor: "pointer", fontSize: "0.84rem", fontWeight: 500, color: "var(--navy)", padding: "8px 12px" }}
           >
@@ -661,7 +683,7 @@ function Landing({ autoConectar, onConectado, onTransparencia, onChangelog, onTe
                 CETES hoy
               </span>
               <span style={{ fontWeight: 700, fontSize: "1rem", color: "#86EFAC" }}>{cetesRate}%</span>
-              <span style={{ fontSize: "0.78rem", color: "rgba(255,255,255,0.45)" }}>vía Etherfuse</span>
+              <span style={{ fontSize: "0.78rem", color: "rgba(255,255,255,0.7)" }}>vía Etherfuse</span>
             </div>
             <div style={{ width: 4, height: 4, borderRadius: "50%", background: "rgba(255,255,255,0.25)" }} />
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -735,19 +757,19 @@ function Landing({ autoConectar, onConectado, onTransparencia, onChangelog, onTe
           <LogoSVG size={20} light />
           <span style={{ fontWeight: 700, fontSize: "1rem", color: "rgba(255,255,255,0.85)" }}>Bimex</span>
         </div>
-        <p style={{ color: "rgba(255,255,255,0.35)", fontSize: "0.78rem", marginBottom: 10 }}>
+        <p style={{ color: "rgba(255,255,255,0.65)", fontSize: "0.78rem", marginBottom: 10 }}>
           Hack+ Alebrije · Stellar · CDMX 2025 · Construido con Soroban y MXNe
         </p>
         <div style={{ display: "flex", justifyContent: "center", gap: 8, flexWrap: "wrap" }}>
-          <button onClick={onChangelog} style={st.footerLinkLanding}>
+          <button type="button" onClick={onChangelog} style={st.footerLinkLanding}>
             Novedades
           </button>
           <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-          <button onClick={onTerminos} style={st.footerLinkLanding}>
+          <button type="button" onClick={onTerminos} style={st.footerLinkLanding}>
             {t("footer.terms")}
           </button>
           <span style={{ color: "rgba(255,255,255,0.2)", fontSize: "0.78rem" }}>·</span>
-          <button onClick={onPrivacidad} style={st.footerLinkLanding}>
+          <button type="button" onClick={onPrivacidad} style={st.footerLinkLanding}>
             {t("footer.privacy")}
           </button>
         </div>
@@ -823,12 +845,12 @@ const st = {
   },
   footerLink: {
     background: "none", border: "none", cursor: "pointer",
-    color: "rgba(255,255,255,0.55)", fontSize: "0.78rem",
+    color: "rgba(255,255,255,0.75)", fontSize: "0.78rem",
     fontWeight: 500, padding: "4px 8px",
   },
   footerLinkLanding: {
     background: "none", border: "none", cursor: "pointer",
-    color: "rgba(255,255,255,0.45)", fontSize: "0.78rem",
+    color: "rgba(255,255,255,0.75)", fontSize: "0.78rem",
     fontWeight: 500, padding: 0,
   },
 };

--- a/bimex-frontend/src/components/CrearProyecto.jsx
+++ b/bimex-frontend/src/components/CrearProyecto.jsx
@@ -121,7 +121,7 @@ function PreviewArchivo({ archivo, onEliminar }) {
   return (
     <div className="archivo-preview" style={estilos.archivoPreview}>
       {esImagen && previewUrl && (
-        <img src={previewUrl} alt="preview" className="archivo-thumb" style={estilos.archivoThumb} />
+        <img src={previewUrl} alt={archivo.name} className="archivo-thumb" style={estilos.archivoThumb} />
       )}
       {esPdf && <span className="archivo-icon" style={estilos.archivoIcon}>📄</span>}
       <div style={{ flex: 1, minWidth: 0 }}>
@@ -461,7 +461,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
                 </div>
               )}
 
-              {error && <p style={estilos.error}>{error}</p>}
+              {error && <p role="alert" aria-live="assertive" style={estilos.error}>{error}</p>}
 
               <div style={{ display: "flex", gap: 12, marginTop: 24 }}>
                 <button type="button" className="btn btn-ghost" onClick={onCerrar} style={{ flex: 1 }}>
@@ -537,7 +537,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
                 </span>
               </div>
 
-              {error && <p style={estilos.error}>{error}</p>}
+              {error && <p role="alert" aria-live="assertive" style={estilos.error}>{error}</p>}
 
               <div style={{ display: "flex", gap: 12, marginTop: 24 }}>
                 <button type="button" className="btn btn-ghost" onClick={() => { setPaso(1); setError(""); }} style={{ flex: 1 }}>
@@ -624,7 +624,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
                 </div>
               </div>
 
-              {error && <p style={estilos.error}>{error}</p>}
+              {error && <p role="alert" aria-live="assertive" style={estilos.error}>{error}</p>}
 
               <div style={{ display: "flex", gap: 12, marginTop: 24 }}>
                 <button type="button" className="btn btn-ghost" onClick={() => { setPaso(2); setError(""); }} style={{ flex: 1 }}>
@@ -689,7 +689,7 @@ function CampoDocumento({ id, label, descripcion, accept, icono, archivo, error,
             }}
           />
           {error && (
-            <p className="archivo-error" style={{ fontSize: "0.74rem", color: "#DC2626", marginTop: 6, display: "flex", alignItems: "center", gap: 4 }}>
+            <p className="archivo-error" role="alert" aria-live="assertive" style={{ fontSize: "0.74rem", color: "#DC2626", marginTop: 6, display: "flex", alignItems: "center", gap: 4 }}>
               <span aria-hidden="true">⚠️</span> {error}
             </p>
           )}

--- a/bimex-frontend/src/i18n/en.json
+++ b/bimex-frontend/src/i18n/en.json
@@ -9,7 +9,8 @@
     "transparency": "Transparency"
   },
   "lang": {
-    "toggle": "ES"
+    "toggle": "ES",
+    "toggleAria": "Switch language to Spanish"
   },
   "tema": {
     "oscuro": "Dark mode",

--- a/bimex-frontend/src/i18n/es.json
+++ b/bimex-frontend/src/i18n/es.json
@@ -9,7 +9,8 @@
     "transparency": "Transparencia"
   },
   "lang": {
-    "toggle": "EN"
+    "toggle": "EN",
+    "toggleAria": "Cambiar idioma a inglés"
   },
   "tema": {
     "oscuro": "Modo oscuro",

--- a/bimex-frontend/src/main.jsx
+++ b/bimex-frontend/src/main.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Buffer } from 'buffer'
 globalThis.Buffer = Buffer
 
@@ -10,3 +11,14 @@ createRoot(document.getElementById('root')).render(
     <App />
   </BrowserRouter>,
 )
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  Promise.all([import('@axe-core/react'), import('react-dom')])
+    .then(([axeModule, ReactDOM]) => {
+      const reactDom = ReactDOM?.default ?? ReactDOM;
+      axeModule.default(React, reactDom, 1000);
+    })
+    .catch(() => {
+      // axe dev helper is optional in development
+    });
+}

--- a/bimex-frontend/src/test/accessibility.test.jsx
+++ b/bimex-frontend/src/test/accessibility.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@stellar/stellar-sdk', () => ({
+  Contract: vi.fn(),
+  Networks: { TESTNET: 'Test SDF Network ; September 2015', PUBLIC: 'Public Global Stellar Network ; September 2015' },
+  rpc: {
+    Server: vi.fn(),
+    Api: {
+      isSimulationError: vi.fn(() => false),
+      isSimulationRestore: vi.fn(() => false),
+      GetTransactionStatus: { SUCCESS: 'SUCCESS', FAILED: 'FAILED' },
+    },
+  },
+  TransactionBuilder: vi.fn(),
+  BASE_FEE: '100',
+  Address: vi.fn(),
+  Keypair: { random: vi.fn(() => ({ publicKey: () => 'GDUMMY' })), fromSecret: vi.fn() },
+  nativeToScVal: vi.fn(),
+  scValToNative: vi.fn(),
+}));
+
+vi.mock('@stellar/freighter-api', () => ({
+  isConnected: vi.fn(),
+  isAllowed: vi.fn(),
+  requestAccess: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  setAllowed: vi.fn(),
+}));
+
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App.jsx';
+import i18n from '../i18n/index.js';
+
+describe('Accessibility', () => {
+  it('updates html lang when the active language changes', async () => {
+    localStorage.removeItem('i18nextLng');
+    await act(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(document.documentElement.lang).toBe('es');
+
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe('en');
+    });
+  });
+});


### PR DESCRIPTION

# Pull Request

## Summary
- Added dev-only `@axe-core/react` integration in `bimex-frontend/src/main.jsx`
- Updated `document.documentElement.lang` when i18n language changes
- Improved toast accessibility with `aria-live`, `role`, and `aria-atomic`
- Added `role="alert"` / `aria-live="assertive"` for inline modal errors
- Added `type="button"` to non-submit buttons and `aria-current="page"` to nav tabs
- Replaced generic preview image alt text with file name
- Added a Vitest accessibility check for HTML `lang` updates

## Files Changed
- `src/main.jsx` — axe-core dev integration
- `src/App.jsx` — lang attribute, toast ARIA, button types, contrast fixes
- `src/components/CrearProyecto.jsx` — file alt text, error alert roles
- `src/i18n/en.json` / `src/i18n/es.json` — accessible language toggle label
- `src/test/accessibility.test.jsx` — new test for lang attribute updates
- `package.json` / `package-lock.json` — added `@axe-core/react` dev dependency

## Testing
```bash
cd bimex-frontend && npm install
cd bimex-frontend && npm test -- --run src/test/accessibility.test.jsx

Closes #75 