### PR TITLE
feat: apply PRs #90 #97 #114 — faucet backend, throttle/useMemo, email HTML templates

### DIFF
--- a/bimex-frontend/.env.example
+++ b/bimex-frontend/.env.example
@@ -3,7 +3,9 @@ VITE_CONTRACT_ID=
 VITE_RPC_URL=https://soroban-testnet.stellar.org
 VITE_TOKEN_MXNE=
 VITE_ADMIN_ADDRESS=
-VITE_FAUCET_SECRET=
+
+# Indexer API URL (for faucet and data queries)
+VITE_API_URL=http://localhost:3001
 
 # Indexer API (for SSE real-time updates)
 VITE_INDEXER_URL=http://localhost:3001

--- a/bimex-frontend/src/App.jsx
+++ b/bimex-frontend/src/App.jsx
@@ -426,7 +426,7 @@ export default function App() {
     ? t("pwa.installed")
     : t("pwa.subtitle");
 
-  function refrescarLista() { setRefrescar(r => r + 1); }
+  const refrescarLista = useCallback(() => { setRefrescar(r => r + 1); }, []);
 
   return (
     <div>

--- a/bimex-frontend/src/components/AdminPanel.jsx
+++ b/bimex-frontend/src/components/AdminPanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { crearThrottle } from "../utils/throttle.js";
 import {
   obtenerTodosLosProyectos,
   aprobarProyecto,
@@ -28,6 +29,7 @@ export default function AdminPanel({ direccion, adminAddress, onCerrar }) {
   const [proyectos,  setProyectos]  = useState([]);
   const [cargando,   setCargando]   = useState(true);
   const [toast,      setToast]      = useState(null);
+  const throttleAdmin = useRef(crearThrottle(3000)).current;
   const modalRef      = useRef(null);
   const botonAbrioRef = useRef(null);
 
@@ -78,22 +80,34 @@ export default function AdminPanel({ direccion, adminAddress, onCerrar }) {
 
   async function manejarAprobar(idProyecto) {
     try {
-      await aprobarProyecto(direccion, idProyecto);
-      mostrarToast(t("admin.toastApproved", { id: idProyecto }));
-      await cargarPendientes();
+      await throttleAdmin.ejecutar(async () => {
+        await aprobarProyecto(direccion, idProyecto);
+        mostrarToast(t("admin.toastApproved", { id: idProyecto }));
+        await cargarPendientes();
+      });
     } catch (err) {
-      mostrarToast(parsearError(err), "error");
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        mostrarToast(err.message, "info");
+      } else {
+        mostrarToast(parsearError(err), "error");
+      }
     }
   }
 
   async function manejarRechazar(idProyecto, motivo) {
     try {
-      await rechazarProyecto(direccion, idProyecto, motivo);
-      mostrarToast(t("admin.toastRejected", { id: idProyecto }));
-      await cargarPendientes();
+      await throttleAdmin.ejecutar(async () => {
+        await rechazarProyecto(direccion, idProyecto, motivo);
+        mostrarToast(t("admin.toastRejected", { id: idProyecto }));
+        await cargarPendientes();
+      });
     } catch (err) {
-      mostrarToast(parsearError(err), "error");
-      throw err;
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        mostrarToast(err.message, "info");
+      } else {
+        mostrarToast(parsearError(err), "error");
+        throw err;
+      }
     }
   }
 

--- a/bimex-frontend/src/components/CrearProyecto.jsx
+++ b/bimex-frontend/src/components/CrearProyecto.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { crearThrottle } from "../utils/throttle.js";
 import { parsearError } from "../utils/errores.js";
 import {
   crearProyecto as crearProyectoContrato,
@@ -187,6 +188,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
   const modalRef = useRef(null);
   const botonAbrioRef = useRef(document.activeElement);
   const [paso, setPaso] = useState(1);
+  const throttleCrear = useRef(crearThrottle(5000)).current;
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -311,15 +313,18 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
   async function manejarSubmit(e) {
     e.preventDefault();
     if (paso !== 3 || !docCid) return;
-    setCargando(true);
     setError("");
     try {
-      const metaStroops = mxneAStroops(Number(forma.meta));
-      const meses = Math.max(1, Math.min(120, Number(forma.tiempoMeses) || 6));
-      await crearProyectoContrato(direccion, forma.nombre, metaStroops, docCid, meses);
-      onCreado();
+      await throttleCrear.ejecutar(async () => {
+        setCargando(true);
+        const metaStroops = mxneAStroops(Number(forma.meta));
+        const meses = Math.max(1, Math.min(120, Number(forma.tiempoMeses) || 6));
+        await crearProyectoContrato(direccion, forma.nombre, metaStroops, docCid, meses);
+        onCreado();
+      });
     } catch (err) {
-      setError(parsearError(err));
+      const mensaje = String(err?.message ?? "");
+      setError(mensaje.toLowerCase().includes("espera") ? mensaje : parsearError(err));
       onError?.(err);
     }
     setCargando(false);
@@ -633,7 +638,7 @@ export default function CrearProyecto({ direccion, onCerrar, onCreado, onError }
                 <button
                   type="submit"
                   className="btn btn-primary"
-                  disabled={cargando}
+                  disabled={cargando || throttleCrear.estaBloqueado()}
                   style={{ flex: 2, justifyContent: "center" }}
                 >
                   {cargando ? t("crear.submitting") : t("crear.submit")}

--- a/bimex-frontend/src/components/DetalleProyecto.jsx
+++ b/bimex-frontend/src/components/DetalleProyecto.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
+import { crearThrottle } from "../utils/throttle.js";
 import { parsearError } from "../utils/errores.js";
 import { QRCodeSVG } from "qrcode.react";
 import {
@@ -165,6 +166,11 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
   const [miYield,           setMiYield]           = useState(BigInt(0));
   const [balanceMXNe,       setBalanceMXNe]       = useState(null);
 
+  const throttleContribuir = useRef(crearThrottle(3000)).current;
+  const throttleRetirar    = useRef(crearThrottle(3000)).current;
+  const throttleReclamar   = useRef(crearThrottle(3000)).current;
+  const throttleAbandonar  = useRef(crearThrottle(5000)).current;
+
   const estado    = proyecto.estado ?? "EtapaInicial";
   const estadoCfg = ESTADO_CONFIG[estado] ?? ESTADO_CONFIG.EtapaInicial;
   const esDueno      = direccion === proyecto.dueno;
@@ -183,7 +189,11 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
   const meta       = Number(proyecto.meta ?? 0);
   const porcentaje = meta > 0 ? Math.min((aportado / meta) * 100, 100) : 0;
 
-  const yieldDueno = esDueno ? estimarYieldDueno(proyecto) : BigInt(0);
+  const yieldDueno = useMemo(() => (
+    esDueno
+      ? estimarYieldDueno(proyecto)
+      : BigInt(0)
+  ), [esDueno, proyecto.aportado, proyecto.capital_en_cetes, proyecto.capital_en_amm, proyecto.timestamp_inicio]);
 
   // Documentos IPFS: "CID1|CID2|CID3" → array
   const DOC_LABELS = [
@@ -191,9 +201,11 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
     t("detalle.docPlan"),
     t("detalle.docPresupuesto"),
   ];
-  const docs = proyecto.doc_hash
-    ? proyecto.doc_hash.split("|").filter(Boolean)
-    : [];
+  const docs = useMemo(() => (
+    proyecto.doc_hash
+      ? proyecto.doc_hash.split("|").filter(Boolean)
+      : []
+  ), [proyecto.doc_hash]);
 
   useEffect(() => {
     if (!proyecto?.id) return () => aplicarMeta(DEFAULT_META);
@@ -283,83 +295,113 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
     ? t("detalle.errBalance", { balance: stroopsAMXNe(balanceMXNe) })
     : null;
 
-  const proyeccion = calcProyeccion(cantidadNum, 12, modoInversion);
+  const proyeccion = useMemo(() => calcProyeccion(cantidadNum, 12, modoInversion), [cantidadNum, modoInversion]);
 
-  async function manejarContribuir() {
+  const manejarContribuir = useCallback(async () => {
     if (!direccion || !cantidadValida || superaBalance) return;
-    setCargando(true);
     try {
-      await contribuirContrato(direccion, proyecto.id, mxneAStroops(Number(cantidad)));
-      onToast?.(t("detalle.toastContributed", { amount: cantidad }));
-      setCantidad("");
-      await refrescar();
+      await throttleContribuir.ejecutar(async () => {
+        setCargando(true);
+        await contribuirContrato(direccion, proyecto.id, mxneAStroops(Number(cantidad)));
+        onToast?.(t("detalle.toastContributed", { amount: cantidad }));
+        setCantidad("");
+        await refrescar();
+      });
     } catch (err) {
-      onError?.(err);
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        onToast?.(err.message, "info");
+      } else {
+        onError?.(err);
+      }
     }
     setCargando(false);
-  }
+  }, [balanceMXNe, cantidad, direccion, onError, onToast, proyecto.id, refrescar, t, throttleContribuir]);
 
-  async function manejarRetirar() {
+  const manejarRetirar = useCallback(async () => {
     if (!direccion) return;
-    setCargando(true);
     try {
-      await retirarPrincipalContrato(direccion, proyecto.id);
-      onToast?.(t("detalle.toastWithdrawn", { amount: stroopsAMXNe(miAportacion) }));
-      setMiAportacion(BigInt(0));
-      setMiYield(BigInt(0));
-      setVistaRetirar(false);
-      await refrescar();
+      await throttleRetirar.ejecutar(async () => {
+        setCargando(true);
+        await retirarPrincipalContrato(direccion, proyecto.id);
+        onToast?.(t("detalle.toastWithdrawn", { amount: stroopsAMXNe(miAportacion) }));
+        setMiAportacion(BigInt(0));
+        setMiYield(BigInt(0));
+        setVistaRetirar(false);
+        await refrescar();
+      });
     } catch (err) {
-      onError?.(err);
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        onToast?.(err.message, "info");
+      } else {
+        onError?.(err);
+      }
     }
     setCargando(false);
-  }
+  }, [direccion, miAportacion, onError, onToast, proyecto.id, refrescar, t, throttleRetirar]);
 
-  async function manejarReclamarYield() {
+  const manejarReclamarYield = useCallback(async () => {
     if (!direccion) return;
     if (estado !== "Liberado") { onError?.(t("detalle.errYieldOnly")); return; }
     if (miYield === BigInt(0)) { onError?.(t("detalle.errNoYield")); return; }
-    setCargando(true);
     try {
-      await reclamarYieldContrato(direccion, proyecto.id);
-      onToast?.(t("detalle.toastYield"));
-      await refrescar();
+      await throttleReclamar.ejecutar(async () => {
+        setCargando(true);
+        await reclamarYieldContrato(direccion, proyecto.id);
+        onToast?.(t("detalle.toastYield"));
+        await refrescar();
+      });
     } catch (err) {
-      onError?.(err);
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        onToast?.(err.message, "info");
+      } else {
+        onError?.(err);
+      }
     }
     setCargando(false);
-  }
+  }, [direccion, estado, miYield, onError, onToast, proyecto.id, refrescar, t, throttleReclamar]);
 
-  async function manejarAbandonar() {
+  const manejarAbandonar = useCallback(async () => {
     if (!direccion) return;
     setConfirmarAbandonar(false);
-    setCargando(true);
     try {
-      await abandonarProyectoContrato(direccion, proyecto.id);
-      onToast?.(t("detalle.toastAbandoned"));
-      await refrescar();
+      await throttleAbandonar.ejecutar(async () => {
+        setCargando(true);
+        await abandonarProyectoContrato(direccion, proyecto.id);
+        onToast?.(t("detalle.toastAbandoned"));
+        await refrescar();
+      });
     } catch (err) {
-      onError?.(err);
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        onToast?.(err.message, "info");
+      } else {
+        onError?.(err);
+      }
     }
     setCargando(false);
-  }
+  }, [direccion, onError, onToast, proyecto.id, refrescar, t, throttleAbandonar]);
 
-  async function manejarRetiroAnticipado() {
+  const manejarRetiroAnticipado = useCallback(async () => {
     if (!direccion) return;
-    setCargando(true);
     try {
-      await retiroAnticipadoContrato(direccion, proyecto.id);
-      onToast?.(t("detalle.toastWithdrawn", { amount: stroopsAMXNe(miAportacion) }));
-      setMiAportacion(BigInt(0));
-      setMiYield(BigInt(0));
-      await refrescar();
+      await throttleRetirar.ejecutar(async () => {
+        setCargando(true);
+        await retiroAnticipadoContrato(direccion, proyecto.id);
+        onToast?.(t("detalle.toastWithdrawn", { amount: stroopsAMXNe(miAportacion) }));
+        setMiAportacion(BigInt(0));
+        setMiYield(BigInt(0));
+        await refrescar();
+      });
     } catch (err) {
-      onError?.(err);
+      if (String(err?.message ?? "").toLowerCase().includes("espera")) {
+        onToast?.(err.message, "info");
+      } else {
+        onError?.(err);
+      }
     }
     setCargando(false);
-  }
+  }, [direccion, miAportacion, onError, onToast, proyecto.id, refrescar, t, throttleRetirar]);
 
-  async function manejarSolicitarContinuar() {
+  const manejarSolicitarContinuar = useCallback(async () => {
     if (!direccion) return;
     setCargando(true);
     try {
@@ -370,7 +412,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
       onError?.(err);
     }
     setCargando(false);
-  }
+  }, [direccion, onError, onToast, proyecto.id, refrescar, t]);
 
   return (
     <>
@@ -690,7 +732,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
                     <button
                       className="invest-btn"
                       onClick={manejarContribuir}
-                      disabled={cargando || !direccion || !cantidadValida || !!errorCantidad}
+                      disabled={cargando || !direccion || !cantidadValida || !!errorCantidad || throttleContribuir.estaBloqueado()}
                     >
                       {cargando ? t("detalle.processing") : t("detalle.confirmContribute")}
                     </button>
@@ -717,7 +759,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
                         className="btn btn-ghost"
                         style={{ width: "100%", justifyContent: "center", marginTop: 8, fontSize: "0.82rem", color: "var(--muted)" }}
                         onClick={manejarRetiroAnticipado}
-                        disabled={cargando || !direccion}
+                        disabled={cargando || !direccion || throttleRetirar.estaBloqueado()}
                         title={t("detalle.earlyWithdrawTitle")}
                       >
                         {cargando ? t("detalle.processing") : t("detalle.earlyWithdraw")}
@@ -737,7 +779,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
                         className="btn btn-amber"
                         style={{ width: "100%", justifyContent: "center", marginTop: aceptaFondos ? 0 : 4 }}
                         onClick={() => setVistaRetirar(true)}
-                        disabled={cargando || !direccion}
+                        disabled={cargando || !direccion || throttleRetirar.estaBloqueado()}
                       >
                         {t("detalle.withdraw")}
                       </button>
@@ -758,7 +800,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
                             className="btn btn-amber"
                             style={{ flex: 2, justifyContent: "center" }}
                             onClick={manejarRetirar}
-                            disabled={cargando || !direccion}
+                            disabled={cargando || !direccion || throttleRetirar.estaBloqueado()}
                           >
                             {cargando ? t("detalle.processing") : t("detalle.confirmWithdraw")}
                           </button>
@@ -774,7 +816,7 @@ export default function DetalleProyecto({ direccion, onCerrar, onError, onToast 
                     className="btn btn-secondary"
                     style={{ width: "100%", justifyContent: "center", marginTop: 8 }}
                     onClick={manejarReclamarYield}
-                    disabled={cargando || !direccion || miYield === BigInt(0)}
+                    disabled={cargando || !direccion || miYield === BigInt(0) || throttleReclamar.estaBloqueado()}
                     title={miYield === BigInt(0) ? t("detalle.waitYield") : ""}
                   >
                     {cargando ? t("detalle.processing") : t("detalle.claimYield")}

--- a/bimex-frontend/src/components/ListaProyectos.jsx
+++ b/bimex-frontend/src/components/ListaProyectos.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { obtenerTodosLosProyectos, stroopsAMXNe } from "../stellar/contrato";
@@ -84,7 +84,7 @@ export default function ListaProyectos({ onCrear, refrescar }) {
     { key: "Abandonado",   label: t("filters.abandoned"),  dot: "var(--error)"  },
   ];
 
-  async function cargar() {
+  const cargar = useCallback(async () => {
     if (cargandoRef.current) return;
     cargandoRef.current = true;
     setCargando(true);
@@ -108,9 +108,9 @@ export default function ListaProyectos({ onCrear, refrescar }) {
       setCargando(false);
       cargandoRef.current = false;
     }
-  }
+  }, []);
 
-  useEffect(() => { cargar(); }, [refrescar]);
+  useEffect(() => { cargar(); }, [cargar, refrescar]);
   useEffect(() => { setVisibles(12); }, [filtro]);
   useEffect(() => {
     const timer = setTimeout(() => setBusquedaDebounced(textoBusqueda), 300);
@@ -128,7 +128,7 @@ export default function ListaProyectos({ onCrear, refrescar }) {
     es.addEventListener('yield_reclamado', recargar);
     es.onerror = () => es.close();
     return () => es.close();
-  }, []);
+  }, [cargar]);
 
   const proyectosPublicos = useMemo(
     () => proyectos.filter(p => !ESTADOS_OCULTOS.has(p.estado)),
@@ -167,6 +167,14 @@ export default function ListaProyectos({ onCrear, refrescar }) {
       return null;
     }
   }, [cacheTimestamp, i18n.language]);
+
+  const limpiarBusqueda = useCallback(() => {
+    setTextoBusqueda("");
+  }, []);
+
+  const cargarMas = useCallback(() => {
+    setVisibles((valorActual) => valorActual + 12);
+  }, []);
 
   return (
     <div className="lista-contenedor" style={estilos.contenedor}>
@@ -257,7 +265,7 @@ export default function ListaProyectos({ onCrear, refrescar }) {
               <button
                 type="button"
                 className="btn btn-ghost"
-                onClick={() => setTextoBusqueda("")}
+                onClick={limpiarBusqueda}
                 aria-label={t("lista.limpiarBusqueda")}
                 style={estilos.busquedaClear}
               >
@@ -364,7 +372,7 @@ export default function ListaProyectos({ onCrear, refrescar }) {
             <div style={{ display: "flex", justifyContent: "center", marginTop: 24 }}>
               <button
                 className="btn btn-ghost"
-                onClick={() => setVisibles(v => v + 12)}
+                onClick={cargarMas}
               >
                 {t("lista.loadMore")} ({proyectosFiltrados.length - visibles} {t("lista.remaining")})
               </button>
@@ -422,7 +430,7 @@ const ESTADO_CFG = {
 };
 
 // ── Card ─────────────────────────────────────────────────────────────────────
-function CardProyecto({ proyecto }) {
+const CardProyecto = memo(function CardProyecto({ proyecto }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const meta     = Number(proyecto.meta);
@@ -502,7 +510,7 @@ function CardProyecto({ proyecto }) {
       </button>
     </article>
   );
-}
+});
 
 function StatItem({ label, valor, muted }) {
   return (

--- a/bimex-frontend/src/components/MiCuenta.jsx
+++ b/bimex-frontend/src/components/MiCuenta.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { createClient } from "@supabase/supabase-js";
 import { parsearError } from "../utils/errores.js";
@@ -180,7 +180,7 @@ function MetricCard({ icon, label, value, accent }) {
 
 // ─── Pestaña: Mis proyectos ───────────────────────────────────────────────────
 
-function CardMiProyecto({ proyecto, onVerProyecto }) {
+const CardMiProyecto = memo(function CardMiProyecto({ proyecto, onVerProyecto }) {
   const { t } = useTranslation();
   const progreso = pct(proyecto.aportado, proyecto.meta);
 
@@ -231,11 +231,11 @@ function CardMiProyecto({ proyecto, onVerProyecto }) {
       </button>
     </article>
   );
-}
+});
 
 function TabMisProyectos({ proyectos, direccion, onVerProyecto }) {
   const { t } = useTranslation();
-  const misProyectos = proyectos.filter((p) => p.dueno === direccion);
+  const misProyectos = useMemo(() => proyectos.filter((p) => p.dueno === direccion), [proyectos, direccion]);
 
   if (misProyectos.length === 0) {
     return (
@@ -612,7 +612,7 @@ export default function MiCuenta({ direccion, onVerProyecto, onTotalInvertido })
     cargar();
   }, [direccion]);
 
-  const numCreados = proyectos.filter((p) => p.dueno === direccion).length;
+  const numCreados = useMemo(() => proyectos.filter((p) => p.dueno === direccion).length, [proyectos, direccion]);
 
   const [numApoyados,   setNumApoyados]   = useState(null);
   const [totalInvertido, setTotalInvertido] = useState(null);

--- a/bimex-frontend/src/stellar/contrato.js
+++ b/bimex-frontend/src/stellar/contrato.js
@@ -367,53 +367,24 @@ export async function reclamarYield(direccion, idProyecto) {
   return firmarYEnviar(tx, direccion);
 }
 
-// ─── Faucet — TESTNET ONLY — do not call on Mainnet ──────────────────────────
+// ─── Faucet — TESTNET ONLY — delegates to indexer API ─────────────────────
 
-/**
- * Mintea 100 MXNe de prueba a la dirección indicada.
- * Firma con la clave de faucet (solo testnet, clave en .env.local).
- * WARNING: This function must NOT be exposed in the production UI.
- */
+const FAUCET_API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
+
 export async function mintearMXNePrueba(direccionDestino) {
   if (CONFIG.NETWORK_PASSPHRASE !== Networks.TESTNET) {
     throw new Error("mintearMXNePrueba solo está disponible en Testnet.");
   }
 
-  const secretFaucet = import.meta.env.VITE_FAUCET_SECRET;
-  if (!secretFaucet) throw new Error("Faucet no configurado (VITE_FAUCET_SECRET)");
+  const res = await fetch(`${FAUCET_API_URL}/faucet`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ destino: direccionDestino }),
+  });
 
-  const faucetKeypair = Keypair.fromSecret(secretFaucet);
-  const tokenContrato = new Contract(CONFIG.TOKEN_MXNE);
-  const cuentaInfo    = await servidor.getAccount(faucetKeypair.publicKey());
-
-  const tx = new TransactionBuilder(cuentaInfo, {
-    fee: "1000000",
-    networkPassphrase: CONFIG.NETWORK_PASSPHRASE,
-  })
-    .addOperation(tokenContrato.call(
-      "mint",
-      new Address(direccionDestino).toScVal(),
-      nativeToScVal(BigInt(1_000_000_000), { type: "i128" }), // 100 MXNe
-    ))
-    .setTimeout(300)
-    .build();
-
-  const txPreparada = await servidor.prepareTransaction(tx);
-  txPreparada.sign(faucetKeypair);
-
-  const envio = await servidor.sendTransaction(txPreparada);
-  if (envio.status === "ERROR") throw new Error("Faucet tx rechazada por la red");
-
-  let intentos = 0;
-  while (intentos < 20) {
-    await new Promise(r => setTimeout(r, 2000));
-    const estado = await servidor.getTransaction(envio.hash);
-    if (estado.status === rpc.Api.GetTransactionStatus.SUCCESS) return 100;
-    if (estado.status === rpc.Api.GetTransactionStatus.FAILED)
-      throw new Error("Faucet tx falló en la red");
-    intentos++;
-  }
-  throw new Error("Timeout del faucet");
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error ?? "Faucet request falló");
+  return data.cantidad;
 }
 
 // ─── Verificación documental ──────────────────────────────────────────────────

--- a/bimex-frontend/src/test/throttle.test.js
+++ b/bimex-frontend/src/test/throttle.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { crearThrottle } from '../utils/throttle.js';
+
+describe('crearThrottle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-29T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('ejecuta la función la primera vez y bloquea llamadas repetidas durante el cooldown', async () => {
+    const throttle = crearThrottle(3000);
+    const fn = vi.fn(() => Promise.resolve('ok'));
+
+    await expect(throttle.ejecutar(fn)).resolves.toBe('ok');
+    await expect(throttle.ejecutar(fn)).rejects.toThrow(/Espera 3 segundos/);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('marca el bloqueo mientras dura el cooldown y lo libera al vencerse', async () => {
+    const throttle = crearThrottle(3000);
+    const fn = vi.fn(() => Promise.resolve('ok'));
+
+    await throttle.ejecutar(fn);
+    expect(throttle.estaBloqueado()).toBe(true);
+
+    vi.advanceTimersByTime(3000);
+    expect(throttle.estaBloqueado()).toBe(false);
+  });
+
+  it('devuelve el tiempo restante en el mensaje de cooldown', async () => {
+    const throttle = crearThrottle(3000);
+    const fn = vi.fn(() => Promise.resolve('ok'));
+
+    await throttle.ejecutar(fn);
+    await expect(throttle.ejecutar(fn)).rejects.toThrow('Espera 3 segundos antes de intentar de nuevo');
+  });
+});

--- a/bimex-frontend/src/utils/throttle.js
+++ b/bimex-frontend/src/utils/throttle.js
@@ -1,0 +1,22 @@
+export function crearThrottle(delayMs = 3000) {
+  let ultimaLlamada = 0;
+
+  return {
+    ejecutar: function (fn) {
+      const ahora = Date.now();
+      const diferencia = ahora - ultimaLlamada;
+
+      if (diferencia < delayMs) {
+        const segundosRestantes = Math.max(1, Math.ceil((delayMs - diferencia) / 1000));
+        return Promise.reject(new Error(`Espera ${segundosRestantes} segundos antes de intentar de nuevo`));
+      }
+
+      ultimaLlamada = ahora;
+      return fn();
+    },
+    estaBloqueado: function () {
+      const ahora = Date.now();
+      return ahora - ultimaLlamada < delayMs;
+    }
+  };
+}

--- a/bimex-indexer/.env.example
+++ b/bimex-indexer/.env.example
@@ -12,3 +12,7 @@ API_PORT=3002
 HEALTH_PORT=3001
 # Allowed origin for SSE CORS (set to your frontend URL in production)
 FRONTEND_URL=http://localhost:5173
+
+# Faucet (testnet only — secret key, never VITE_ prefixed)
+FAUCET_SECRET=
+TOKEN_MXNE=CDDIGHPVTW4PSCQCU67NQ4NXZ4NX5GDLNL3O67WT5RQ4GT6RXIEYPC4P

--- a/bimex-indexer/api.js
+++ b/bimex-indexer/api.js
@@ -1,9 +1,27 @@
 import 'dotenv/config';
 import http from 'node:http';
+import { Contract, rpc, TransactionBuilder, Networks, Address, Keypair, nativeToScVal } from '@stellar/stellar-sdk';
 import supabase from './database.js';
 import { agregarCliente, eliminarCliente } from './sse.js';
 
 const PORT = parseInt(process.env.API_PORT ?? '3002', 10);
+
+// ─── Rate limiter: 3 requests per wallet per hour ────────────────────────
+const rateLimitMap = new Map();
+const RL_MAX = 3;
+const RL_WINDOW_MS = 60 * 60 * 1000;
+
+function checkRateLimit(wallet) {
+  const now = Date.now();
+  const entries = rateLimitMap.get(wallet) || [];
+  const recent = entries.filter(t => now - t < RL_WINDOW_MS);
+  if (recent.length >= RL_MAX) return false;
+  recent.push(now);
+  rateLimitMap.set(wallet, recent);
+  return true;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
 
 function json(res, status, data) {
   const body = JSON.stringify(data);
@@ -11,9 +29,85 @@ function json(res, status, data) {
   res.end(body);
 }
 
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', chunk => raw += chunk);
+    req.on('end', () => {
+      try { resolve(JSON.parse(raw)); }
+      catch { reject(new Error('Cuerpo inválido: se esperaba JSON')); }
+    });
+    req.on('error', reject);
+  });
+}
+
+// ─── Faucet — TESTNET ONLY ───────────────────────────────────────────────
+
+const FAUCET_RPC        = new rpc.Server(process.env.STELLAR_RPC_URL, { allowHttp: false });
+const FAUCET_TOKEN_ID   = process.env.TOKEN_MXNE;
+const FAUCET_SECRET     = process.env.FAUCET_SECRET;
+const FAUCET_KEYPAIR    = FAUCET_SECRET ? Keypair.fromSecret(FAUCET_SECRET) : null;
+
+async function mintearMXNe(destino, cantidad = BigInt(1_000_000_000)) {
+  if (!FAUCET_SECRET || !FAUCET_KEYPAIR) throw new Error('Faucet no configurado (FAUCET_SECRET)');
+  if (!FAUCET_TOKEN_ID) throw new Error('Token MXNe no configurado (TOKEN_MXNE)');
+
+  const tokenContrato = new Contract(FAUCET_TOKEN_ID);
+  const cuentaInfo    = await FAUCET_RPC.getAccount(FAUCET_KEYPAIR.publicKey());
+
+  const tx = new TransactionBuilder(cuentaInfo, {
+    fee: '1000000',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(tokenContrato.call('mint', new Address(destino).toScVal(), nativeToScVal(cantidad, { type: 'i128' })))
+    .setTimeout(300)
+    .build();
+
+  const txPreparada = await FAUCET_RPC.prepareTransaction(tx);
+  txPreparada.sign(FAUCET_KEYPAIR);
+
+  const envio = await FAUCET_RPC.sendTransaction(txPreparada);
+  if (envio.status === 'ERROR') throw new Error('Faucet tx rechazada por la red');
+
+  let intentos = 0;
+  while (intentos < 20) {
+    await new Promise(r => setTimeout(r, 2000));
+    const estado = await FAUCET_RPC.getTransaction(envio.hash);
+    if (estado.status === rpc.Api.GetTransactionStatus.SUCCESS) return estado;
+    if (estado.status === rpc.Api.GetTransactionStatus.FAILED)
+      throw new Error('Faucet tx falló en la red');
+    intentos++;
+  }
+  throw new Error('Timeout del faucet');
+}
+
+// ─── Routes ──────────────────────────────────────────────────────────────
+
 async function route(req, res) {
   const url = new URL(req.url, `http://localhost`);
   const parts = url.pathname.replace(/^\//, '').split('/');
+
+  // POST /faucet
+  if (req.method === 'POST' && parts[0] === 'faucet' && !parts[1]) {
+    let body;
+    try { body = await readBody(req); }
+    catch (e) { return json(res, 400, { error: e.message }); }
+
+    const { destino } = body;
+    if (!destino) return json(res, 400, { error: 'Falta "destino" en el cuerpo' });
+
+    if (!checkRateLimit(destino))
+      return json(res, 429, { error: 'Límite de 3 solicitudes por hora por wallet' });
+
+    try {
+      await mintearMXNe(destino);
+      return json(res, 200, { exito: true, cantidad: 100 });
+    } catch (e) {
+      return json(res, 500, { error: e.message });
+    }
+  }
+
+  if (req.method !== 'GET') return json(res, 405, { error: 'Method not allowed' });
 
   // GET /proyectos[?estado=X]
   if (parts[0] === 'proyectos' && !parts[1]) {
@@ -95,10 +189,13 @@ async function route(req, res) {
 
 const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
-    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET' });
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
     return res.end();
   }
-  if (req.method !== 'GET') return json(res, 405, { error: 'Method not allowed' });
   try {
     await route(req, res);
   } catch (err) {

--- a/bimex-indexer/notifications.js
+++ b/bimex-indexer/notifications.js
@@ -5,6 +5,10 @@ import {
   tmplFinanciado,
   tmplYield,
   tmplRetiro,
+  tmplBienvenida,
+  tmplContribucion,
+  tmplAprobacionHTML,
+  tmplYieldDisponible,
 } from "./templates/index.js";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -12,24 +16,31 @@ const FROM   = process.env.RESEND_FROM ?? "Bimex <notificaciones@bimex.fi>";
 const BASE   = process.env.FRONTEND_URL ?? "https://bimex.fi";
 
 const TEMPLATES = {
+  // Legacy templates (simple HTML)
   proyecto_aprobado:  { subject: "✅ Tu proyecto Bimex ha sido aprobado",          html: tmplAprobado  },
   proyecto_rechazado: { subject: "❌ Tu proyecto Bimex ha sido rechazado",          html: tmplRechazado },
   meta_alcanzada:     { subject: "🎉 ¡Tu proyecto alcanzó su meta de financiamiento!", html: tmplFinanciado },
   yield_disponible:   { subject: "💰 Tienes yield disponible para reclamar",        html: tmplYield     },
   retiro_principal:   { subject: "🏦 Se realizó un retiro de principal en tu proyecto", html: tmplRetiro },
+
+  // New HTML templates (professional design)
+  bienvenida:             { subject: "🎉 ¡Bienvenido a Bimex!",                       html: tmplBienvenida },
+  nueva_contribucion:     { subject: "💰 Nueva contribución recibida en tu proyecto", html: tmplContribucion },
+  proyecto_aprobado_html: { subject: "✅ Tu proyecto Bimex ha sido aprobado",         html: tmplAprobacionHTML },
+  yield_disponible_html:  { subject: "💰 Tienes yield disponible para reclamar",      html: tmplYieldDisponible },
 };
 
 /**
  * Send a notification email for a given event.
  * @param {string} eventType  - One of the keys in TEMPLATES
  * @param {string} toEmail    - Recipient email address
- * @param {object} data       - { nombreProyecto, idProyecto, motivo?, monto? }
+ * @param {object} data       - Template data (nombreProyecto, idProyecto, monto?, progreso?, etc.)
  */
 export async function enviarNotificacion(eventType, toEmail, data) {
   const tpl = TEMPLATES[eventType];
   if (!tpl) throw new Error(`Tipo de evento desconocido: ${eventType}`);
 
-  const proyectoUrl = `${BASE}/?proyecto=${data.idProyecto}`;
+  const proyectoUrl = data.proyectoUrl ?? `${BASE}/?proyecto=${data.idProyecto}`;
   const html = tpl.html({ ...data, proyectoUrl });
 
   const { error } = await resend.emails.send({

--- a/bimex-indexer/templates/aprobacion.html
+++ b/bimex-indexer/templates/aprobacion.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Proyecto Aprobado - Bimex</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #F9FAFB; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #FFFFFF; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(30, 58, 95, 0.08);">
+          <tr>
+            <td style="background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); padding: 32px 40px; text-align: center;">
+              <h1 style="margin: 0; font-size: 28px; font-weight: 700; color: #FFFFFF; letter-spacing: -0.02em;">Bimex</h1>
+              <p style="margin: 8px 0 0; font-size: 14px; color: rgba(255, 255, 255, 0.8); font-weight: 500;">Financiamiento colaborativo en blockchain</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding-bottom: 24px;">
+                    <div style="width: 64px; height: 64px; background: linear-gradient(135deg, #16A34A 0%, #22C55E 100%); border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 32px;">
+                      ✅
+                    </div>
+                  </td>
+                </tr>
+              </table>
+              <h2 style="margin: 0 0 16px; font-size: 24px; font-weight: 700; color: #1E3A5F; text-align: center; line-height: 1.3;">
+                ¡Tu proyecto fue aprobado!
+              </h2>
+              <p style="margin: 0 0 32px; font-size: 16px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Excelentes noticias. El equipo de Bimex revisó tu proyecto y lo aprobó. Ya está visible para que los backers puedan contribuir.
+              </p>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F0FDF4; border: 2px solid #BBF7D0; border-radius: 8px; margin-bottom: 24px;">
+                <tr>
+                  <td style="padding: 20px;">
+                    <p style="margin: 0 0 4px; font-size: 11px; font-weight: 700; color: #166534; text-transform: uppercase; letter-spacing: 0.08em;">
+                      PROYECTO APROBADO
+                    </p>
+                    <p style="margin: 0; font-size: 18px; font-weight: 700; color: #111827;">
+                      {{nombreProyecto}}
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 8px 0;">
+                    <a href="{{proyectoUrl}}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); color: #FFFFFF; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 16px; box-shadow: 0 4px 12px rgba(30, 58, 95, 0.2);">
+                      Ver mi proyecto →
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px; background-color: #F9FAFB; border-top: 1px solid #E5E7EB;">
+              <p style="margin: 0 0 12px; font-size: 12px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Recibiste este correo porque tienes notificaciones activas en Bimex.
+              </p>
+              <p style="margin: 0; font-size: 12px; text-align: center;">
+                <a href="{{baseUrl}}/terminos" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Términos</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{baseUrl}}/privacidad" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Privacidad</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{unsubscribeUrl}}" style="color: #6B7280; text-decoration: none;">Desuscribirse</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/bimex-indexer/templates/bienvenida.html
+++ b/bimex-indexer/templates/bienvenida.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Bienvenido a Bimex</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #F9FAFB; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #FFFFFF; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(30, 58, 95, 0.08);">
+          <tr>
+            <td style="background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); padding: 32px 40px; text-align: center;">
+              <h1 style="margin: 0; font-size: 28px; font-weight: 700; color: #FFFFFF; letter-spacing: -0.02em;">Bimex</h1>
+              <p style="margin: 8px 0 0; font-size: 14px; color: rgba(255, 255, 255, 0.8); font-weight: 500;">Financiamiento colaborativo en blockchain</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding-bottom: 24px;">
+                    <div style="width: 64px; height: 64px; background: linear-gradient(135deg, #16A34A 0%, #22C55E 100%); border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 32px;">
+                      🎉
+                    </div>
+                  </td>
+                </tr>
+              </table>
+              <h2 style="margin: 0 0 16px; font-size: 24px; font-weight: 700; color: #1E3A5F; text-align: center; line-height: 1.3;">
+                ¡Bienvenido a Bimex!
+              </h2>
+              <p style="margin: 0 0 32px; font-size: 16px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Acabas de realizar tu primera contribución. Gracias por formar parte de la comunidad de financiamiento colaborativo en blockchain.
+              </p>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F0FDF4; border: 2px solid #BBF7D0; border-radius: 8px; margin-bottom: 24px;">
+                <tr>
+                  <td style="padding: 20px;">
+                    <p style="margin: 0 0 4px; font-size: 11px; font-weight: 700; color: #166534; text-transform: uppercase; letter-spacing: 0.08em;">
+                      TU PRIMERA CONTRIBUCIÓN
+                    </p>
+                    <p style="margin: 0 0 8px; font-size: 18px; font-weight: 700; color: #111827;">
+                      {{nombreProyecto}}
+                    </p>
+                    <p style="margin: 0; font-size: 20px; font-weight: 700; color: #16A34A;">
+                      {{monto}} MXNe
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 8px 0 24px;">
+                    <a href="{{proyectoUrl}}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); color: #FFFFFF; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 16px; box-shadow: 0 4px 12px rgba(30, 58, 95, 0.2);">
+                      Ver mi contribución →
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px; background-color: #F9FAFB; border-top: 1px solid #E5E7EB;">
+              <p style="margin: 0 0 12px; font-size: 12px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Recibiste este correo porque tienes notificaciones activas en Bimex.
+              </p>
+              <p style="margin: 0; font-size: 12px; text-align: center;">
+                <a href="{{baseUrl}}/terminos" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Términos</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{baseUrl}}/privacidad" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Privacidad</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{unsubscribeUrl}}" style="color: #6B7280; text-decoration: none;">Desuscribirse</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/bimex-indexer/templates/contribucion.html
+++ b/bimex-indexer/templates/contribucion.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Nueva Contribución - Bimex</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #F9FAFB; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #FFFFFF; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(30, 58, 95, 0.08);">
+          <tr>
+            <td style="background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); padding: 32px 40px; text-align: center;">
+              <h1 style="margin: 0; font-size: 28px; font-weight: 700; color: #FFFFFF; letter-spacing: -0.02em;">Bimex</h1>
+              <p style="margin: 8px 0 0; font-size: 14px; color: rgba(255, 255, 255, 0.8); font-weight: 500;">Financiamiento colaborativo en blockchain</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding-bottom: 24px;">
+                    <div style="width: 64px; height: 64px; background: linear-gradient(135deg, #16A34A 0%, #22C55E 100%); border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 32px;">
+                      💰
+                    </div>
+                  </td>
+                </tr>
+              </table>
+              <h2 style="margin: 0 0 16px; font-size: 24px; font-weight: 700; color: #1E3A5F; text-align: center; line-height: 1.3;">
+                ¡Nueva contribución recibida!
+              </h2>
+              <p style="margin: 0 0 32px; font-size: 16px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Tu proyecto ha recibido una nueva contribución. Estás más cerca de alcanzar tu meta de financiamiento.
+              </p>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; border: 1px solid #E5E7EB; border-radius: 8px; margin-bottom: 24px;">
+                <tr>
+                  <td style="padding: 20px;">
+                    <p style="margin: 0 0 4px; font-size: 11px; font-weight: 700; color: #1E3A5F; text-transform: uppercase; letter-spacing: 0.08em;">
+                      PROYECTO
+                    </p>
+                    <p style="margin: 0 0 16px; font-size: 18px; font-weight: 700; color: #111827;">
+                      {{nombreProyecto}}
+                    </p>
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="padding: 12px 0; border-top: 1px solid #E5E7EB;">
+                          <p style="margin: 0 0 4px; font-size: 12px; color: #6B7280; font-weight: 500;">Monto contribuido</p>
+                          <p style="margin: 0; font-size: 20px; font-weight: 700; color: #16A34A;">{{monto}} MXNe</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 12px 0; border-top: 1px solid #E5E7EB;">
+                          <p style="margin: 0 0 8px; font-size: 12px; color: #6B7280; font-weight: 500;">Progreso total</p>
+                          <div style="width: 100%; height: 8px; background-color: #E5E7EB; border-radius: 99px; overflow: hidden;">
+                            <div style="width: {{progreso}}%; height: 100%; background: linear-gradient(90deg, #16A34A 0%, #22C55E 100%); border-radius: 99px;"></div>
+                          </div>
+                          <p style="margin: 8px 0 0; font-size: 14px; font-weight: 600; color: #374151;">{{progreso}}% completado</p>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 8px 0 24px;">
+                    <a href="{{proyectoUrl}}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); color: #FFFFFF; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 16px; box-shadow: 0 4px 12px rgba(30, 58, 95, 0.2);">
+                      Ver mi proyecto →
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px; background-color: #F9FAFB; border-top: 1px solid #E5E7EB;">
+              <p style="margin: 0 0 12px; font-size: 12px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Recibiste este correo porque tienes notificaciones activas en Bimex.
+              </p>
+              <p style="margin: 0; font-size: 12px; text-align: center;">
+                <a href="{{baseUrl}}/terminos" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Términos</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{baseUrl}}/privacidad" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Privacidad</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{unsubscribeUrl}}" style="color: #6B7280; text-decoration: none;">Desuscribirse</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/bimex-indexer/templates/htmlTemplates.js
+++ b/bimex-indexer/templates/htmlTemplates.js
@@ -1,0 +1,43 @@
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const BASE = process.env.FRONTEND_URL ?? "https://bimex.fi";
+
+function loadTemplate(templateName, variables = {}) {
+  const templatePath = join(__dirname, `${templateName}.html`);
+  let html = readFileSync(templatePath, "utf-8");
+
+  const allVars = {
+    baseUrl: BASE,
+    unsubscribeUrl: `${BASE}/mi-cuenta`,
+    tasaCetes: "10.5",
+    ...variables,
+  };
+
+  Object.entries(allVars).forEach(([key, value]) => {
+    const regex = new RegExp(`{{${key}}}`, "g");
+    html = html.replace(regex, value ?? "");
+  });
+
+  return html;
+}
+
+export function tmplBienvenida(data) {
+  return loadTemplate("bienvenida", data);
+}
+
+export function tmplContribucion(data) {
+  return loadTemplate("contribucion", data);
+}
+
+export function tmplAprobacionHTML(data) {
+  return loadTemplate("aprobacion", data);
+}
+
+export function tmplYieldDisponible(data) {
+  return loadTemplate("yield-disponible", data);
+}

--- a/bimex-indexer/templates/index.js
+++ b/bimex-indexer/templates/index.js
@@ -1,1 +1,2 @@
 export { tmplAprobado, tmplRechazado, tmplFinanciado, tmplYield, tmplRetiro } from "./emails.js";
+export { tmplBienvenida, tmplContribucion, tmplAprobacionHTML, tmplYieldDisponible } from "./htmlTemplates.js";

--- a/bimex-indexer/templates/yield-disponible.html
+++ b/bimex-indexer/templates/yield-disponible.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Yield Disponible - Bimex</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #F9FAFB; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #FFFFFF; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(30, 58, 95, 0.08);">
+          <tr>
+            <td style="background: linear-gradient(135deg, #1E3A5F 0%, #2D5282 100%); padding: 32px 40px; text-align: center;">
+              <h1 style="margin: 0; font-size: 28px; font-weight: 700; color: #FFFFFF; letter-spacing: -0.02em;">Bimex</h1>
+              <p style="margin: 8px 0 0; font-size: 14px; color: rgba(255, 255, 255, 0.8); font-weight: 500;">Financiamiento colaborativo en blockchain</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding-bottom: 24px;">
+                    <div style="width: 64px; height: 64px; background: linear-gradient(135deg, #D97706 0%, #F59E0B 100%); border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 32px;">
+                      💰
+                    </div>
+                  </td>
+                </tr>
+              </table>
+              <h2 style="margin: 0 0 16px; font-size: 24px; font-weight: 700; color: #1E3A5F; text-align: center; line-height: 1.3;">
+                Tienes yield disponible para reclamar
+              </h2>
+              <p style="margin: 0 0 32px; font-size: 16px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Tu proyecto ha acumulado rendimiento (CETES + AMM) que puedes reclamar ahora mismo.
+              </p>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background: linear-gradient(135deg, #FEF3C7 0%, #FDE68A 100%); border: 2px solid #FCD34D; border-radius: 12px; margin-bottom: 24px;">
+                <tr>
+                  <td style="padding: 28px; text-align: center;">
+                    <p style="margin: 0 0 8px; font-size: 13px; font-weight: 700; color: #92400E; text-transform: uppercase; letter-spacing: 0.08em;">
+                      Yield acumulado
+                    </p>
+                    <p style="margin: 0; font-size: 36px; font-weight: 700; color: #92400E; line-height: 1.2;">
+                      {{monto}} MXNe
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; border: 1px solid #E5E7EB; border-radius: 8px; margin-bottom: 24px;">
+                <tr>
+                  <td style="padding: 16px;">
+                    <p style="margin: 0 0 4px; font-size: 11px; font-weight: 700; color: #1E3A5F; text-transform: uppercase; letter-spacing: 0.08em;">
+                      PROYECTO
+                    </p>
+                    <p style="margin: 0; font-size: 16px; font-weight: 700; color: #111827;">
+                      {{nombreProyecto}}
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 8px 0 24px;">
+                    <a href="{{proyectoUrl}}" style="display: inline-block; padding: 16px 40px; background: linear-gradient(135deg, #D97706 0%, #F59E0B 100%); color: #FFFFFF; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 16px; box-shadow: 0 4px 12px rgba(217, 119, 6, 0.3);">
+                      Reclamar yield →
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #EFF6FF; border: 1px solid #BFDBFE; border-radius: 8px;">
+                <tr>
+                  <td style="padding: 16px;">
+                    <p style="margin: 0; font-size: 13px; color: #1E40AF; line-height: 1.6;">
+                      <strong>ℹ️ Recuerda:</strong> El yield se acumula automáticamente mientras tu proyecto está financiado. Puedes reclamarlo en cualquier momento sin penalización.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px; background-color: #F9FAFB; border-top: 1px solid #E5E7EB;">
+              <p style="margin: 0 0 12px; font-size: 12px; color: #6B7280; text-align: center; line-height: 1.6;">
+                Recibiste este correo porque tienes notificaciones activas en Bimex.
+              </p>
+              <p style="margin: 0; font-size: 12px; text-align: center;">
+                <a href="{{baseUrl}}/terminos" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Términos</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{baseUrl}}/privacidad" style="color: #1E3A5F; text-decoration: none; font-weight: 500;">Privacidad</a>
+                <span style="color: #D1D5DB; margin: 0 8px;">·</span>
+                <a href="{{unsubscribeUrl}}" style="color: #6B7280; text-decoration: none;">Desuscribirse</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/bimex/contracts/bimex/src/lib.rs
+++ b/bimex/contracts/bimex/src/lib.rs
@@ -112,9 +112,36 @@ const DEFAULT_AMM_BPS:   u32 = 400;  // 4.00 % anual (liquidez AMM)
 // Segundos por mes (30 días)
 const SEGUNDOS_POR_MES: u64 = 30 * 24 * 3_600;
 
+// TTL en ledgers (~1 ledger = 5 segundos)
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;    // ~1 día
+const INSTANCE_BUMP_AMOUNT: u32 = 518_400;           // ~30 días
+
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 17_280;   // ~1 día
+const PERSISTENT_BUMP_AMOUNT: u32 = 2_592_000;       // ~6 meses
+
 // ============================================================
 //  HELPERS
 // ============================================================
+
+fn extender_ttl_instancia(env: &Env) {
+    env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+fn extender_ttl_proyecto(env: &Env, id: u32) {
+    env.storage().persistent().extend_ttl(
+        &Clave::Proyecto(id),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+fn extender_ttl_aportacion(env: &Env, id: u32, backer: &Address) {
+    env.storage().persistent().extend_ttl(
+        &Clave::Aportacion(id, backer.clone()),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
 
 /// Overflow-safe yield calculation.
 ///
@@ -166,6 +193,7 @@ impl BimexContrato {
         env.storage().instance().set(&Clave::YieldCetesBps, &yield_cetes_bps);
         env.storage().instance().set(&Clave::YieldAmmBps, &yield_amm_bps);
         env.storage().instance().set(&Clave::ContadorProyectos, &0u32);
+        extender_ttl_instancia(&env);
     }
 
     /// Crea un nuevo proyecto en estado EnRevision.
@@ -212,6 +240,8 @@ impl BimexContrato {
 
         env.storage().persistent().set(&Clave::Proyecto(id), &proyecto);
         env.storage().instance().set(&Clave::ContadorProyectos, &(id + 1));
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id);
         id
     }
 
@@ -278,6 +308,9 @@ impl BimexContrato {
         }
 
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
+        extender_ttl_aportacion(&env, id_proyecto, &backer);
 
         env.events().publish(
             (symbol_short!("contribuir"), backer.clone()),
@@ -305,6 +338,9 @@ impl BimexContrato {
         let yield_cetes = calcular_yield_seguro(mitad, cetes_bps, minutos);
         let yield_amm   = calcular_yield_seguro(aportacion.cantidad - mitad, amm_bps, minutos);
 
+        extender_ttl_instancia(&env);
+        extender_ttl_aportacion(&env, id_proyecto, &backer);
+
         yield_cetes + yield_amm
     }
 
@@ -323,6 +359,9 @@ impl BimexContrato {
         let yield_cetes = calcular_yield_seguro(proyecto.capital_en_cetes, cetes_bps, minutos);
         let yield_amm   = calcular_yield_seguro(proyecto.capital_en_amm,   amm_bps,   minutos);
 
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
+
         YieldDetallado { cetes: yield_cetes, amm: yield_amm, total: yield_cetes + yield_amm }
     }
 
@@ -331,6 +370,8 @@ impl BimexContrato {
         let proyecto: Proyecto = env
             .storage().persistent().get(&Clave::Proyecto(id_proyecto))
             .expect("Proyecto no existe");
+
+        extender_ttl_proyecto(&env, id_proyecto);
 
         CapitalEstado {
             en_cetes: proyecto.capital_en_cetes,
@@ -380,6 +421,8 @@ impl BimexContrato {
         proyecto.yield_amm_acumulado   += yield_amm;
         proyecto.timestamp_inicio       = ahora;
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
 
         env.events().publish(
             (symbol_short!("yield"), proyecto.dueno.clone()),
@@ -434,6 +477,9 @@ impl BimexContrato {
         let monto = aportacion.cantidad;
 
         // EFFECTS first
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
+        extender_ttl_aportacion(&env, id_proyecto, &backer);
         env.storage().persistent().remove(&Clave::Aportacion(id_proyecto, backer.clone()));
         proyecto.total_aportado -= monto;
 
@@ -500,6 +546,9 @@ impl BimexContrato {
         let monto = aportacion.cantidad;
 
         // EFFECTS first — yield acumulado se queda en el proyecto
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
+        extender_ttl_aportacion(&env, id_proyecto, &backer);
         env.storage().persistent().remove(&Clave::Aportacion(id_proyecto, backer.clone()));
         proyecto.total_aportado -= monto;
 
@@ -541,6 +590,8 @@ impl BimexContrato {
 
         proyecto.estado = EstadoProyecto::Abandonado;
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
     }
 
     /// Permite a un nuevo dueño retomar un proyecto Abandonado.
@@ -572,6 +623,8 @@ impl BimexContrato {
         };
 
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
     }
 
     /// Aprueba un proyecto en revisión. Solo el admin puede llamarlo.
@@ -592,6 +645,8 @@ impl BimexContrato {
 
         proyecto.estado = EstadoProyecto::EtapaInicial;
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
 
         env.events().publish(
             (symbol_short!("aprobar"), admin.clone()),
@@ -619,6 +674,8 @@ impl BimexContrato {
         proyecto.estado = EstadoProyecto::Rechazado;
         proyecto.motivo_rechazo = motivo;
         env.storage().persistent().set(&Clave::Proyecto(id_proyecto), &proyecto);
+        extender_ttl_instancia(&env);
+        extender_ttl_proyecto(&env, id_proyecto);
 
         env.events().publish(
             (symbol_short!("rechazar"), admin.clone()),
@@ -626,16 +683,40 @@ impl BimexContrato {
         );
     }
 
+    /// Transfiere el rol de administrador a una nueva dirección.
+    /// Solo el admin actual puede llamar esta función.
+    pub fn admin_cambiar_admin(env: Env, admin_actual: Address, nuevo_admin: Address) {
+        admin_actual.require_auth();
+        let guardado: Address = env.storage().instance().get(&Clave::Admin).expect("No inicializado");
+        assert!(admin_actual == guardado, "Solo el admin actual puede transferir el rol");
+        assert!(nuevo_admin != admin_actual, "El nuevo admin debe ser diferente");
+
+        env.storage().instance().set(&Clave::Admin, &nuevo_admin);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("adm_chg"), admin_actual, nuevo_admin.clone()),
+            nuevo_admin
+        );
+
+        extender_ttl_instancia(&env);
+    }
+
     pub fn obtener_proyecto(env: Env, id: u32) -> Proyecto {
-        env.storage().persistent().get(&Clave::Proyecto(id)).expect("Proyecto no existe")
+        let proyecto: Proyecto = env.storage().persistent().get(&Clave::Proyecto(id)).expect("Proyecto no existe");
+        extender_ttl_proyecto(&env, id);
+        proyecto
     }
 
     pub fn obtener_aportacion(env: Env, id_proyecto: u32, backer: Address) -> Aportacion {
-        env.storage().persistent().get(&Clave::Aportacion(id_proyecto, backer)).expect("Sin aportacion")
+        let aportacion: Aportacion = env.storage().persistent().get(&Clave::Aportacion(id_proyecto, backer.clone())).expect("Sin aportacion");
+        extender_ttl_aportacion(&env, id_proyecto, &backer);
+        aportacion
     }
 
     pub fn total_proyectos(env: Env) -> u32 {
-        env.storage().instance().get(&Clave::ContadorProyectos).unwrap_or(0)
+        let total = env.storage().instance().get(&Clave::ContadorProyectos).unwrap_or(0);
+        extender_ttl_instancia(&env);
+        total
     }
 
     pub fn admin_pausar(env: Env, admin: Address) {

--- a/bimex/contracts/bimex/src/test.rs
+++ b/bimex/contracts/bimex/src/test.rs
@@ -906,3 +906,78 @@ fn test_admin_aprobacion_funciona_pausado() {
     assert_eq!(cliente.obtener_proyecto(&id_rechazar).estado, EstadoProyecto::Rechazado);
 }
 
+
+// ============================================================
+//  TTL TESTS
+// ============================================================
+
+#[test]
+fn test_extend_ttl() {
+    let (env, cliente, _admin, dueno, backer) = setup();
+
+    let id = cliente.crear_proyecto(
+        &dueno,
+        &String::from_str(&env, "Proyecto TTL"),
+        &100_000_000i128,
+        &doc_cid_vacio(&env),
+        &6u32,
+    );
+
+    cliente.admin_aprobar(&id);
+    cliente.contribuir(&backer, &id, &10_000_000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 17_281);
+
+    assert_eq!(cliente.total_proyectos(), 1);
+
+    let proyecto = cliente.obtener_proyecto(&id);
+    assert_eq!(proyecto.nombre, String::from_str(&env, "Proyecto TTL"));
+
+    let aportacion = cliente.obtener_aportacion(&id, &backer);
+    assert_eq!(aportacion.cantidad, 10_000_000i128);
+}
+
+// ============================================================
+//  ADMIN ROTATION TESTS
+// ============================================================
+
+#[test]
+fn test_admin_cambiar_admin_exito() {
+    let (env, cliente, admin, dueno, _backer) = setup();
+    let nuevo_admin = Address::generate(&env);
+
+    cliente.admin_cambiar_admin(&admin, &nuevo_admin);
+
+    let id = cliente.crear_proyecto(&dueno, &String::from_str(&env, "Proyecto A"), &10_000_000i128, &doc_cid_vacio(&env), &6u32);
+    cliente.admin_aprobar(&id);
+
+    let p = cliente.obtener_proyecto(&id);
+    assert_eq!(p.estado, EstadoProyecto::EtapaInicial);
+}
+
+#[test]
+#[should_panic(expected = "Solo el admin actual puede transferir el rol")]
+fn test_admin_cambiar_admin_no_autorizado() {
+    let (env, cliente, _admin, dueno, _backer) = setup();
+    let nuevo_admin = Address::generate(&env);
+
+    cliente.admin_cambiar_admin(&dueno, &nuevo_admin);
+}
+
+#[test]
+fn test_admin_cambiar_admin_emite_evento() {
+    let (env, cliente, admin, _dueno, _backer) = setup();
+    let nuevo_admin = Address::generate(&env);
+
+    cliente.admin_cambiar_admin(&admin, &nuevo_admin);
+
+    let eventos = env.events().all();
+    assert_eq!(eventos.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "El nuevo admin debe ser diferente")]
+fn test_admin_cambiar_admin_mismo_admin_falla() {
+    let (_env, cliente, admin, _dueno, _backer) = setup();
+    cliente.admin_cambiar_admin(&admin, &admin);
+}


### PR DESCRIPTION
## Resumen

Aplicación directa del código de los PRs #90, #97 y #114 por el maintainer.

### PR #90 — Faucet backend + TTL contrato + rotación de admin
- `bimex-indexer/api.js`: endpoint POST `/faucet` con rate limiter en memoria (3 req/hr/wallet)
- `bimex-frontend/src/stellar/contrato.js`: `mintearMXNePrueba` ahora llama a la API en vez de firmar en el cliente
- `bimex/contracts/bimex/src/lib.rs`: TTL extension helpers + `admin_cambiar_admin`
- `bimex/contracts/bimex/src/test.rs`: 5 nuevos tests (TTL + rotación admin)
- `.env.example` actualizados en frontend e indexer

### PR #97 — React performance (throttle, useCallback, useMemo, memo)
- Nuevo `bimex-frontend/src/utils/throttle.js` con `crearThrottle(delayMs)`
- Nuevo `bimex-frontend/src/test/throttle.test.js` (3 tests)
- Throttle en `AdminPanel`, `CrearProyecto`, `DetalleProyecto`
- `memo(CardProyecto)` en `ListaProyectos`, `memo(CardMiProyecto)` en `MiCuenta`
- `useMemo` para listas filtradas y cálculos derivados
- `useCallback` en handlers de carga y `refrescarLista` en `App.jsx`

### PR #114 — Templates HTML de email para indexer
- Nuevo `bimex-indexer/templates/htmlTemplates.js` (loader con `readFileSync` + sustitución `{{variable}}`)
- 4 nuevos templates HTML: `bienvenida`, `contribucion`, `aprobacion`, `yield-disponible`
- `notifications.js`: 4 nuevos tipos de evento (`bienvenida`, `nueva_contribucion`, `proyecto_aprobado_html`, `yield_disponible_html`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JfnhH2CghRyxav22rfM8bQ)_