### PR TITLE
feat: apply PR #116 — i18n formatting utilities (formato.js)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Cargo.lock
 
 # ===== CLAUDE =====
 .claude/
+
+# ===== TEST OUTPUT =====
+test-output/

--- a/bimex-frontend/src/components/Recompensas.jsx
+++ b/bimex-frontend/src/components/Recompensas.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { obtenerTodosLosProyectos, obtenerAportacion } from "../stellar/contrato";
+import { formatearNumero, formatearNumeroConDecimales } from "../utils/formato.js";
 
 // ── Niveles de confianza ──────────────────────────────────────────────────────
 const NIVELES = [
@@ -235,7 +236,7 @@ export default function Recompensas({ direccion, refrescar, totalInvertido: tota
                 <div style={{ height: "100%", width: `${pct}%`, background: nivel.color, borderRadius: 99, transition: "width 0.6s ease" }} />
               </div>
               <p style={{ fontSize: "0.72rem", color: "var(--muted)", marginTop: 6 }}>
-                {t("recompensas.remaining", { amount: Math.max(0, siguiente.min - totalMXNe).toLocaleString("es-MX", { maximumFractionDigits: 2 }) })}
+                {t("recompensas.remaining", { amount: formatearNumeroConDecimales(Math.max(0, siguiente.min - totalMXNe), 2) })}
               </p>
             </div>
           )}
@@ -259,7 +260,7 @@ export default function Recompensas({ direccion, refrescar, totalInvertido: tota
                 disabled={!r.desbloqueado}
                 aria-label={r.desbloqueado
                   ? t("recompensas.ariaUnlocked", { name: r.nombre })
-                  : t("recompensas.ariaLocked", { name: r.nombre, amount: r.umbral.toLocaleString("es-MX") })}
+                  : t("recompensas.ariaLocked", { name: r.nombre, amount: formatearNumero(r.umbral) })}
                 style={{
                   ...st.recompensaBtn,
                   opacity: r.desbloqueado ? 1 : 0.45,

--- a/bimex-frontend/src/test/formato.test.js
+++ b/bimex-frontend/src/test/formato.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import i18n from '../i18n/index.js';
+import {
+  formatearMXNe,
+  formatearFecha,
+  formatearPorcentaje,
+  formatearNumero,
+  formatearNumeroConDecimales,
+} from '../utils/formato.js';
+
+describe('Formatting utilities', () => {
+  describe('formatearMXNe', () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    it('formats stroops to MXNe in Spanish', () => {
+      const stroops = 12345670000; // 1,234.567 MXNe
+      const result = formatearMXNe(stroops);
+      expect(result).toBe('1,234.57');
+    });
+
+    it('formats stroops to MXNe in English', async () => {
+      await i18n.changeLanguage('en');
+      const stroops = 12345670000; // 1,234.567 MXNe
+      const result = formatearMXNe(stroops);
+      expect(result).toBe('1,234.57');
+    });
+
+    it('handles zero', () => {
+      expect(formatearMXNe(0)).toBe('0.00');
+    });
+
+    it('handles bigint input', () => {
+      const stroops = BigInt(10000000); // 1 MXNe
+      const result = formatearMXNe(stroops);
+      expect(result).toBe('1.00');
+    });
+  });
+
+  describe('formatearFecha', () => {
+    it('formats timestamp in Spanish', async () => {
+      await i18n.changeLanguage('es');
+      const timestamp = 1716940800; // May 29, 2024
+      const result = formatearFecha(timestamp);
+      // Spanish format: "29 may 2024" or similar
+      expect(result).toMatch(/may/i);
+      expect(result).toContain('2024');
+    });
+
+    it('formats timestamp in English', async () => {
+      await i18n.changeLanguage('en');
+      const timestamp = 1716940800; // May 29, 2024
+      const result = formatearFecha(timestamp);
+      // English format: "May 29, 2024" or similar
+      expect(result).toMatch(/may/i);
+      expect(result).toContain('2024');
+    });
+  });
+
+  describe('formatearPorcentaje', () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    it('formats percentage correctly', () => {
+      const result = formatearPorcentaje(5);
+      expect(result).toContain('5');
+      expect(result).toContain('%');
+    });
+
+    it('formats decimal percentage', () => {
+      const result = formatearPorcentaje(5.5);
+      expect(result).toContain('5.5');
+      expect(result).toContain('%');
+    });
+  });
+
+  describe('formatearNumero', () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    it('formats number without decimals in Spanish', () => {
+      const result = formatearNumero(1234567);
+      expect(result).toBe('1,234,567');
+    });
+
+    it('formats number without decimals in English', async () => {
+      await i18n.changeLanguage('en');
+      const result = formatearNumero(1234567);
+      expect(result).toBe('1,234,567');
+    });
+
+    it('rounds decimal numbers', () => {
+      const result = formatearNumero(1234.567);
+      expect(result).toBe('1,235');
+    });
+  });
+
+  describe('formatearNumeroConDecimales', () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    it('formats number with 2 decimals by default', () => {
+      const result = formatearNumeroConDecimales(1234.567);
+      expect(result).toBe('1,234.57');
+    });
+
+    it('formats number with custom decimals', () => {
+      const result = formatearNumeroConDecimales(1234.56789, 4);
+      expect(result).toBe('1,234.5679');
+    });
+
+    it('pads with zeros when needed', () => {
+      const result = formatearNumeroConDecimales(1234, 2);
+      expect(result).toBe('1,234.00');
+    });
+  });
+
+  describe('Language switching', () => {
+    it('updates formatting when language changes', async () => {
+      await i18n.changeLanguage('es');
+      let result = formatearFecha(1716940800);
+      const esFormat = result;
+
+      await i18n.changeLanguage('en');
+      result = formatearFecha(1716940800);
+      const enFormat = result;
+
+      // Formats should be different (though both contain the date)
+      expect(esFormat).toBeTruthy();
+      expect(enFormat).toBeTruthy();
+    });
+  });
+});

--- a/bimex-frontend/src/utils/formato.js
+++ b/bimex-frontend/src/utils/formato.js
@@ -1,0 +1,39 @@
+import i18n from '../i18n';
+
+export function formatearMXNe(stroops) {
+  const b = typeof stroops === "bigint" ? stroops : BigInt(stroops ?? 0);
+  const valor = Number(b / BigInt(10_000_000)) + Number(b % BigInt(10_000_000)) / 10_000_000;
+  return new Intl.NumberFormat(i18n.language, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(valor);
+}
+
+export function formatearFecha(timestamp) {
+  return new Intl.DateTimeFormat(i18n.language, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(timestamp * 1000));
+}
+
+export function formatearPorcentaje(valor) {
+  return new Intl.NumberFormat(i18n.language, {
+    style: 'percent',
+    minimumFractionDigits: 2,
+  }).format(valor / 100);
+}
+
+export function formatearNumero(numero) {
+  return new Intl.NumberFormat(i18n.language, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(numero);
+}
+
+export function formatearNumeroConDecimales(numero, decimales = 2) {
+  return new Intl.NumberFormat(i18n.language, {
+    minimumFractionDigits: decimales,
+    maximumFractionDigits: decimales,
+  }).format(numero);
+}


### PR DESCRIPTION
Aplicación directa del código de PR #116 (Zarmaijemimah) por el maintainer.

### Cambios incluidos

- **`bimex-frontend/src/utils/formato.js`** (nuevo): utilidades de formateo i18n usando `Intl.NumberFormat` / `Intl.DateTimeFormat` con el locale activo — `formatearMXNe`, `formatearFecha`, `formatearPorcentaje`, `formatearNumero`, `formatearNumeroConDecimales`. Fix de precisión: usa división entera BigInt en `formatearMXNe` para evitar pérdida de precisión en montos grandes.
- **`bimex-frontend/src/test/formato.test.js`** (nuevo): 13 tests cubriendo todas las funciones
- **`Recompensas.jsx`**: reemplaza 2 llamadas hardcodeadas a `.toLocaleString("es-MX")` con las nuevas utilidades; agrega el import faltante (bug fix del PR original)
- **`.gitignore`**: agrega `test-output/`

### Excluido del PR original
- Archivos de docs de desarrollo (`.md`)
- `qrcode.react` en `package.json` (sin uso en el código)
- Cambios en `bimex-indexer/` (ya en `main` desde PR #117)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JfnhH2CghRyxav22rfM8bQ)_