### PR TITLE
feat: client-side pagination for project cards in MiCuenta and Transparencia (issue #63)

### DIFF
--- a/bimex-frontend/src/components/MiCuenta.jsx
+++ b/bimex-frontend/src/components/MiCuenta.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { createClient } from "@supabase/supabase-js";
 import { parsearError } from "../utils/errores.js";
 import usePaginacion from "../hooks/usePaginacion";
+import usePaginacionLocal from "../hooks/usePaginacionLocal";
 import Paginacion from "./Paginacion";
 import {
   obtenerTodosLosProyectos,
@@ -236,6 +237,13 @@ const CardMiProyecto = memo(function CardMiProyecto({ proyecto, onVerProyecto })
 function TabMisProyectos({ proyectos, direccion, onVerProyecto }) {
   const { t } = useTranslation();
   const misProyectos = useMemo(() => proyectos.filter((p) => p.dueno === direccion), [proyectos, direccion]);
+  const gridRef = useRef(null);
+  const { datosPagina, pagina, setPagina, totalPaginas } = usePaginacionLocal(misProyectos, [direccion]);
+
+  const handlePaginaChange = (nueva) => {
+    setPagina(nueva);
+    gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   if (misProyectos.length === 0) {
     return (
@@ -252,10 +260,13 @@ function TabMisProyectos({ proyectos, direccion, onVerProyecto }) {
   }
 
   return (
-    <div className="cuenta-grid" style={estilos.grid} role="list" aria-label={t("cuenta.ariaProjects")}>
-      {misProyectos.map((p) => (
-        <CardMiProyecto key={p.id} proyecto={p} onVerProyecto={onVerProyecto} />
-      ))}
+    <div ref={gridRef}>
+      <div className="cuenta-grid" style={estilos.grid} role="list" aria-label={t("cuenta.ariaProjects")}>
+        {datosPagina.map((p) => (
+          <CardMiProyecto key={p.id} proyecto={p} onVerProyecto={onVerProyecto} />
+        ))}
+      </div>
+      <Paginacion pagina={pagina} totalPaginas={totalPaginas} onChange={handlePaginaChange} />
     </div>
   );
 }

--- a/bimex-frontend/src/components/Transparencia.jsx
+++ b/bimex-frontend/src/components/Transparencia.jsx
@@ -4,6 +4,7 @@ import { obtenerTodosLosProyectos, calcularYieldDetallado, stroopsAMXNe } from "
 import { parsearError } from "../utils/errores.js";
 import { createClient } from "@supabase/supabase-js";
 import usePaginacion from "../hooks/usePaginacion";
+import usePaginacionLocal from "../hooks/usePaginacionLocal";
 import Paginacion from "./Paginacion";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.trim();
@@ -100,6 +101,14 @@ export default function Transparencia({ onVolver }) {
   const proyectosFiltrados = filtro === "Todos"
     ? proyectos
     : proyectos.filter(p => p.estado === filtro);
+
+  const gridRef = useRef(null);
+  const { datosPagina, pagina, setPagina, totalPaginas } = usePaginacionLocal(proyectosFiltrados, [filtro]);
+
+  const handlePaginaChange = (nueva) => {
+    setPagina(nueva);
+    gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   return (
     <div style={{ maxWidth: "1140px", margin: "0 auto", padding: "40px 24px" }}>
@@ -264,15 +273,18 @@ export default function Transparencia({ onVolver }) {
               </button>
             </div>
           ) : (
-            <div className="grid-proyectos" style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(285px, 1fr))",
-              gap: 16,
-            }} role="list" aria-label={t("transp.title")}>
-              {proyectosFiltrados.map(p => (
-                <ProyectoCard key={p.id} proyecto={p} />
-              ))}
-            </div>
+            <>
+              <div ref={gridRef} className="grid-proyectos" style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(285px, 1fr))",
+                gap: 16,
+              }} role="list" aria-label={t("transp.title")}>
+                {datosPagina.map(p => (
+                  <ProyectoCard key={p.id} proyecto={p} />
+                ))}
+              </div>
+              <Paginacion pagina={pagina} totalPaginas={totalPaginas} onChange={handlePaginaChange} />
+            </>
           )}
           {/* Paginated contributions table */}
           <div style={{ marginTop: 28 }}>

--- a/bimex-frontend/src/hooks/usePaginacionLocal.js
+++ b/bimex-frontend/src/hooks/usePaginacionLocal.js
@@ -1,0 +1,35 @@
+import { useState, useMemo, useEffect, useRef } from "react";
+
+const PAGINA_SIZE = 20;
+
+export default function usePaginacionLocal(datos, dependencias = []) {
+  const [pagina, setPagina] = useState(0);
+  const prevDepRef = useRef(JSON.stringify(dependencias));
+
+  useEffect(() => {
+    const key = JSON.stringify(dependencias);
+    if (key !== prevDepRef.current) {
+      prevDepRef.current = key;
+      setPagina(0);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencias);
+
+  const total = datos.length;
+  const totalPaginas = Math.ceil(total / PAGINA_SIZE);
+
+  const datosPagina = useMemo(() => {
+    const desde = pagina * PAGINA_SIZE;
+    return datos.slice(desde, desde + PAGINA_SIZE);
+  }, [datos, pagina]);
+
+  useEffect(() => {
+    if (totalPaginas > 0 && pagina >= totalPaginas) {
+      setPagina(Math.max(0, totalPaginas - 1));
+    }
+  }, [totalPaginas, pagina]);
+
+  return { datosPagina, pagina, setPagina, totalPaginas, total };
+}
+
+export { PAGINA_SIZE };


### PR DESCRIPTION
## Summary

Applies the pagination work from PR #87 (Dydex), adapted for the current codebase.

- Adds `src/hooks/usePaginacionLocal.js` — a **client-side** array-slicing pagination hook (20 items/page). This is separate from the existing `usePaginacion.js` (Supabase server-side) to avoid naming conflicts.
- Wires pagination into **`TabMisProyectos`** (`MiCuenta.jsx`) — project cards now paginate instead of rendering all at once.
- Wires pagination into the **project grid** (`Transparencia.jsx`) — public project grid paginates with the existing filter active.
- Reuses the existing `Paginacion` component and i18n keys (`pagination.*`) already in main.

## Changes

| File | Change |
|---|---|
| `src/hooks/usePaginacionLocal.js` | New — client-side pagination hook |
| `src/components/MiCuenta.jsx` | `TabMisProyectos` uses `usePaginacionLocal` |
| `src/components/Transparencia.jsx` | Project grid uses `usePaginacionLocal` |

Closes #63

https://claude.ai/code/session_01JfnhH2CghRyxav22rfM8bQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfnhH2CghRyxav22rfM8bQ)_