### PR TITLE
feat: implement upgrade pattern #55

### DIFF
--- a/bimex/contracts/bimex/src/lib.rs
+++ b/bimex/contracts/bimex/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    symbol_short, token, Address, Env, String,
+    symbol_short, token, Address, BytesN, Env, String,
 };
 
 // ============================================================
@@ -731,6 +731,15 @@ impl BimexContrato {
         let admin_guardado: Address = env.storage().instance().get(&Clave::Admin).expect("No inicializado");
         assert!(admin == admin_guardado, "Solo el admin puede reanudar");
         env.storage().instance().set(&Clave::Pausado, &false);
+    }
+
+    /// Actualiza el WASM del contrato. Solo el admin puede ejecutar esta función.
+    /// El estado (proyectos, aportaciones) se preserva automáticamente en el ledger.
+    pub fn admin_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        let admin_guardado: Address = env.storage().instance().get(&Clave::Admin).expect("No inicializado");
+        assert!(admin == admin_guardado, "Solo el admin puede actualizar el contrato");
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 }
 

--- a/bimex/contracts/bimex/src/test.rs
+++ b/bimex/contracts/bimex/src/test.rs
@@ -981,3 +981,33 @@ fn test_admin_cambiar_admin_mismo_admin_falla() {
     let (_env, cliente, admin, _dueno, _backer) = setup();
     cliente.admin_cambiar_admin(&admin, &admin);
 }
+
+// ============================================================
+//  UPGRADE PATTERN TESTS
+// ============================================================
+
+#[test]
+fn test_solo_admin_puede_upgrade() {
+    let (env, cliente, admin, _dueno, _backer) = setup();
+    
+    // Generar un hash de wasm simulado
+    let mut hash = [0u8; 32];
+    hash[0] = 1;
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &hash);
+    
+    // Esto debería ejecutarse sin error ya que es el admin
+    cliente.admin_upgrade(&admin, &new_wasm_hash);
+}
+
+#[test]
+#[should_panic(expected = "Solo el admin puede actualizar el contrato")]
+fn test_no_admin_no_puede_upgrade() {
+    let (env, cliente, _admin, dueno, _backer) = setup();
+    
+    let mut hash = [0u8; 32];
+    hash[0] = 1;
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &hash);
+    
+    // Esto fallará porque el dueño no es el admin
+    cliente.admin_upgrade(&dueno, &new_wasm_hash);
+}


### PR DESCRIPTION
## Description
Implement upgrade pattern to allow native WASM updates without manual migration.

### Upgrade Flow
1. Compile the new version of the contract:
`cargo build --target wasm32-unknown-unknown --release`

2. Upload the new WASM to the network and obtain the hash:
`stellar contract install --wasm target/wasm32-unknown-unknown/release/bimex.wasm --network testnet`

3. Call admin_upgrade() with the new hash from the admin wallet:
`stellar contract invoke --id <contract_id> --fn admin_upgrade --arg <admin_address> --arg <new_wasm_hash> --network testnet`

Closes #55 
